### PR TITLE
feat(control): add deadband-based ControlDecisionEngine and ingestion…

### DIFF
--- a/docs/ai-collaboration.md
+++ b/docs/ai-collaboration.md
@@ -44,6 +44,13 @@
 4. 핵심 코드 (Key Code): 해결의 열쇠가 되는 핵심 로직 발췌
 5. 배운 점 (Lesson): 기술적 인사이트, 트레이드오프, 주의사항
 
+## Issue Completion Response Bundle
+- 이슈 종료 시 Codex 응답은 아래 4가지를 항상 한 번에 제공한다.
+1. 작업 결과 상세 보고 (What/How/Why/Risk/Test)
+2. 커밋 메시지 제안 (Conventional Commits)
+3. PR 본문 초안 (`.github/pull_request_template.md` 형식)
+4. 블로그용 팩트 리포트 (`Context/Problem/Solution/Key Code/Lesson`)
+
 ## Blog Fact Reporting Style
 - 역할은 '취재 기자' 관점으로, 과장 없이 팩트 중심으로 작성한다.
 - 단순 코드 나열이 아니라 Problem Solving 관점으로 맥락을 연결한다.

--- a/src/main/java/com/iot/IoT/control/ControlAction.java
+++ b/src/main/java/com/iot/IoT/control/ControlAction.java
@@ -1,0 +1,7 @@
+package com.iot.IoT.control;
+
+public enum ControlAction {
+    HEAT_ON,
+    HEAT_OFF,
+    HOLD
+}

--- a/src/main/java/com/iot/IoT/control/ControlDecisionEngine.java
+++ b/src/main/java/com/iot/IoT/control/ControlDecisionEngine.java
@@ -1,0 +1,35 @@
+package com.iot.IoT.control;
+
+import com.iot.IoT.ingestion.dto.DeviceState;
+import com.iot.IoT.ingestion.dto.DeviceStatusMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+
+@Component
+public class ControlDecisionEngine {
+
+    private final BigDecimal deadband;
+
+    public ControlDecisionEngine(@Value("${control.deadband:0.3}") BigDecimal deadband) {
+        this.deadband = deadband;
+    }
+
+    public ControlAction decide(DeviceStatusMessage message) {
+        if (message.state() == DeviceState.OFF) {
+            return ControlAction.HEAT_OFF;
+        }
+
+        BigDecimal lowerBound = message.targetTemp().subtract(deadband);
+        BigDecimal upperBound = message.targetTemp().add(deadband);
+
+        if (message.temp().compareTo(lowerBound) < 0) {
+            return ControlAction.HEAT_ON;
+        }
+        if (message.temp().compareTo(upperBound) > 0) {
+            return ControlAction.HEAT_OFF;
+        }
+        return ControlAction.HOLD;
+    }
+}

--- a/src/main/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImpl.java
+++ b/src/main/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImpl.java
@@ -1,5 +1,7 @@
 package com.iot.IoT.ingestion.service;
 
+import com.iot.IoT.control.ControlAction;
+import com.iot.IoT.control.ControlDecisionEngine;
 import com.iot.IoT.ingestion.dto.DeviceStatusMessage;
 import com.iot.IoT.ingestion.port.HeartbeatPort;
 import com.iot.IoT.ingestion.port.TemperatureTimeSeriesPort;
@@ -16,13 +18,16 @@ public class DeviceIngestionServiceImpl implements DeviceIngestionService {
 
     private final TemperatureTimeSeriesPort temperatureTimeSeriesPort;
     private final HeartbeatPort heartbeatPort;
+    private final ControlDecisionEngine controlDecisionEngine;
 
     public DeviceIngestionServiceImpl(
             TemperatureTimeSeriesPort temperatureTimeSeriesPort,
-            HeartbeatPort heartbeatPort
+            HeartbeatPort heartbeatPort,
+            ControlDecisionEngine controlDecisionEngine
     ) {
         this.temperatureTimeSeriesPort = temperatureTimeSeriesPort;
         this.heartbeatPort = heartbeatPort;
+        this.controlDecisionEngine = controlDecisionEngine;
     }
 
     @Override
@@ -45,5 +50,13 @@ public class DeviceIngestionServiceImpl implements DeviceIngestionService {
         } catch (Exception e) {
             log.error("[INGESTION] Redis heartbeat update failed. deviceId={}", message.deviceId(), e);
         }
+
+        ControlAction action = controlDecisionEngine.decide(message);
+        log.info("[CONTROL] Decision made. deviceId={}, temp={}, targetTemp={}, state={}, action={}",
+                message.deviceId(),
+                message.temp(),
+                message.targetTemp(),
+                message.state(),
+                action);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,8 @@ influxdb:
 
 ingestion:
   heartbeat-ttl-seconds: 120
+control:
+  deadband: 0.3
 
 logging:
   level:

--- a/src/test/java/com/iot/IoT/control/ControlDecisionEngineTest.java
+++ b/src/test/java/com/iot/IoT/control/ControlDecisionEngineTest.java
@@ -1,0 +1,74 @@
+package com.iot.IoT.control;
+
+import com.iot.IoT.ingestion.dto.DeviceState;
+import com.iot.IoT.ingestion.dto.DeviceStatusMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ControlDecisionEngineTest {
+
+    private final ControlDecisionEngine engine = new ControlDecisionEngine(new BigDecimal("0.3"));
+
+    @Test
+    @DisplayName("Should return HEAT_ON when temp is below lower bound")
+    void decide_heatOn() {
+        DeviceStatusMessage message = message("60.0", "65.0", DeviceState.HEATING);
+
+        ControlAction result = engine.decide(message);
+
+        assertEquals(ControlAction.HEAT_ON, result);
+    }
+
+    @Test
+    @DisplayName("Should return HEAT_OFF when temp is above upper bound")
+    void decide_heatOff() {
+        DeviceStatusMessage message = message("65.5", "65.0", DeviceState.HEATING);
+
+        ControlAction result = engine.decide(message);
+
+        assertEquals(ControlAction.HEAT_OFF, result);
+    }
+
+    @Test
+    @DisplayName("Should return HOLD when temp is within deadband")
+    void decide_holdInsideDeadband() {
+        DeviceStatusMessage message = message("65.1", "65.0", DeviceState.HOLDING);
+
+        ControlAction result = engine.decide(message);
+
+        assertEquals(ControlAction.HOLD, result);
+    }
+
+    @Test
+    @DisplayName("Should return HEAT_OFF when state is OFF")
+    void decide_offState() {
+        DeviceStatusMessage message = message("60.0", "65.0", DeviceState.OFF);
+
+        ControlAction result = engine.decide(message);
+
+        assertEquals(ControlAction.HEAT_OFF, result);
+    }
+
+    @Test
+    @DisplayName("Should return HOLD at deadband boundary")
+    void decide_deadbandBoundary() {
+        DeviceStatusMessage lowerBoundary = message("64.7", "65.0", DeviceState.HEATING);
+        DeviceStatusMessage upperBoundary = message("65.3", "65.0", DeviceState.HEATING);
+
+        assertEquals(ControlAction.HOLD, engine.decide(lowerBoundary));
+        assertEquals(ControlAction.HOLD, engine.decide(upperBoundary));
+    }
+
+    private DeviceStatusMessage message(String temp, String targetTemp, DeviceState state) {
+        return new DeviceStatusMessage(
+                "SV-001",
+                new BigDecimal(temp),
+                state,
+                new BigDecimal(targetTemp)
+        );
+    }
+}

--- a/src/test/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImplTest.java
+++ b/src/test/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.iot.IoT.ingestion.service;
 
+import com.iot.IoT.control.ControlDecisionEngine;
 import com.iot.IoT.ingestion.dto.DeviceState;
 import com.iot.IoT.ingestion.dto.DeviceStatusMessage;
 import com.iot.IoT.ingestion.port.HeartbeatPort;
@@ -21,13 +22,15 @@ class DeviceIngestionServiceImplTest {
 
     private TemperatureTimeSeriesPort temperatureTimeSeriesPort;
     private HeartbeatPort heartbeatPort;
+    private ControlDecisionEngine controlDecisionEngine;
     private DeviceIngestionServiceImpl service;
 
     @BeforeEach
     void setUp() {
         temperatureTimeSeriesPort = Mockito.mock(TemperatureTimeSeriesPort.class);
         heartbeatPort = Mockito.mock(HeartbeatPort.class);
-        service = new DeviceIngestionServiceImpl(temperatureTimeSeriesPort, heartbeatPort);
+        controlDecisionEngine = Mockito.mock(ControlDecisionEngine.class);
+        service = new DeviceIngestionServiceImpl(temperatureTimeSeriesPort, heartbeatPort, controlDecisionEngine);
     }
 
     @Test


### PR DESCRIPTION
## Summary                                                                                                      
                                                                                                                  
  - 변경 배경: Ingestion 이후 실제 제어 판단 로직이 없어 온도 기반 동작 결정을 일관되게 수행할 수 없었습니다.     
  - 핵심 변경사항: deadband 기반 ControlDecisionEngine 추가 및 DeviceIngestionService 연동                        
                                                                                                                  
  ## Why                                                                                                          
                                                                                                                  
  - 고트래픽 IoT 환경에서 경계 온도 근처 신호 진동을 막기 위해 히스테리시스 기반 제어가 필요합니다.               
  - 판단 로직을 분리해 테스트 가능성과 유지보수성을 높였습니다.                                                   
                                                                                                                  
  ## Changes                                                                                                      
                                                                                                                  
  - [ ] Ingestion                                                                                                 
  - [x] Control Loop                                                                                              
  - [ ] Watchdog/Fail-safe                                                                                        
  - [x] Infra/Config                                                                                              
  - [ ] Docs                                                                                                      
  - ControlAction enum 추가 (HEAT_ON, HEAT_OFF, HOLD)                                                             
  - ControlDecisionEngine 추가 (control.deadband 적용)                                                            
  - DeviceIngestionServiceImpl에 제어 판단 및 표준 로그 추가                                                      
  - application.yml에 control.deadband: 0.3 추가                                                                  
  - 제어 엔진 단위 테스트 및 서비스 테스트 갱신                                                                   
                                                                                                                  
  ## Test Evidence                                                                                                
                                                                                                                  
  - 실행 커맨드:                                                                                                  
      - ./gradlew test --tests com.iot.IoT.control.ControlDecisionEngineTest --tests                              
        com.iot.IoT.ingestion.service.DeviceIngestionServiceImplTest --tests                                      
        com.iot.IoT.ingestion.parser.MqttPayloadParserTest                                                        
  - 결과 요약:                                                                                                    
      - BUILD SUCCESSFUL                                                                                          
                                                                                                                  
  ## Risk & Rollback                                                                                              
                                                                                                                  
  - 예상 리스크:                                                                                                  
      - deadband 튜닝값 부적절 시 과민/둔감 제어 가능                                                             
  - 롤백 방법:                                                                                                    
      - 본 PR revert로 기존 ingestion-only 흐름으로 복구 가능                                                     
                                                                                                                  
  ## Checklist                                                                                                    
  - [x] 예외/에러 처리 경로를 점검했다.
  - [x] 테스트를 추가/갱신했다.
  - [x] 성능 영향(고트래픽 관점)을 검토했다.