### PR TITLE
feat(ingestion): add per-stage ingestion metrics for high-load diagnostics

### DIFF
--- a/src/main/java/com/iot/IoT/ingestion/metrics/IngestionMetricsCollector.java
+++ b/src/main/java/com/iot/IoT/ingestion/metrics/IngestionMetricsCollector.java
@@ -1,0 +1,106 @@
+package com.iot.IoT.ingestion.metrics;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+
+@Component
+@ConditionalOnProperty(prefix = "ingestion.metrics", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class IngestionMetricsCollector {
+
+    private static final Logger log = LoggerFactory.getLogger(IngestionMetricsCollector.class);
+
+    private final LongAdder mqttReceivedTotal = new LongAdder();
+    private final LongAdder parseSuccessTotal = new LongAdder();
+    private final LongAdder parseFailureTotal = new LongAdder();
+    private final LongAdder influxSuccessTotal = new LongAdder();
+    private final LongAdder influxFailureTotal = new LongAdder();
+    private final LongAdder redisSuccessTotal = new LongAdder();
+    private final LongAdder redisFailureTotal = new LongAdder();
+
+    private final AtomicLong lastMqttReceived = new AtomicLong(0);
+    private final AtomicLong lastParseSuccess = new AtomicLong(0);
+    private final AtomicLong lastParseFailure = new AtomicLong(0);
+    private final AtomicLong lastInfluxSuccess = new AtomicLong(0);
+    private final AtomicLong lastInfluxFailure = new AtomicLong(0);
+    private final AtomicLong lastRedisSuccess = new AtomicLong(0);
+    private final AtomicLong lastRedisFailure = new AtomicLong(0);
+
+    public void recordMqttReceived() {
+        mqttReceivedTotal.increment();
+    }
+
+    public void recordParseSuccess() {
+        parseSuccessTotal.increment();
+    }
+
+    public void recordParseFailure() {
+        parseFailureTotal.increment();
+    }
+
+    public void recordInfluxSuccess() {
+        influxSuccessTotal.increment();
+    }
+
+    public void recordInfluxFailure() {
+        influxFailureTotal.increment();
+    }
+
+    public void recordRedisSuccess() {
+        redisSuccessTotal.increment();
+    }
+
+    public void recordRedisFailure() {
+        redisFailureTotal.increment();
+    }
+
+    @Scheduled(fixedDelayString = "${ingestion.metrics-log-interval-ms:1000}")
+    public void logSnapshot() {
+        long mqttReceived = mqttReceivedTotal.sum();
+        long parseSuccess = parseSuccessTotal.sum();
+        long parseFailure = parseFailureTotal.sum();
+        long influxSuccess = influxSuccessTotal.sum();
+        long influxFailure = influxFailureTotal.sum();
+        long redisSuccess = redisSuccessTotal.sum();
+        long redisFailure = redisFailureTotal.sum();
+
+        long mqttReceivedDelta = mqttReceived - lastMqttReceived.getAndSet(mqttReceived);
+        long parseSuccessDelta = parseSuccess - lastParseSuccess.getAndSet(parseSuccess);
+        long parseFailureDelta = parseFailure - lastParseFailure.getAndSet(parseFailure);
+        long influxSuccessDelta = influxSuccess - lastInfluxSuccess.getAndSet(influxSuccess);
+        long influxFailureDelta = influxFailure - lastInfluxFailure.getAndSet(influxFailure);
+        long redisSuccessDelta = redisSuccess - lastRedisSuccess.getAndSet(redisSuccess);
+        long redisFailureDelta = redisFailure - lastRedisFailure.getAndSet(redisFailure);
+
+        if (mqttReceivedDelta == 0
+                && parseSuccessDelta == 0
+                && parseFailureDelta == 0
+                && influxSuccessDelta == 0
+                && influxFailureDelta == 0
+                && redisSuccessDelta == 0
+                && redisFailureDelta == 0) {
+            return;
+        }
+
+        log.info("[INGEST-METRICS/1s] recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, redisOk={}, redisFail={} | totals recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, redisOk={}, redisFail={}",
+                mqttReceivedDelta,
+                parseSuccessDelta,
+                parseFailureDelta,
+                influxSuccessDelta,
+                influxFailureDelta,
+                redisSuccessDelta,
+                redisFailureDelta,
+                mqttReceived,
+                parseSuccess,
+                parseFailure,
+                influxSuccess,
+                influxFailure,
+                redisSuccess,
+                redisFailure);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,9 @@ influxdb:
 
 ingestion:
   heartbeat-ttl-seconds: 120
+  metrics:
+    enabled: true
+  metrics-log-interval-ms: 1000
 control:
   deadband: 0.3
 watchdog:

--- a/src/test/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImplTest.java
+++ b/src/test/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImplTest.java
@@ -3,6 +3,7 @@ package com.iot.IoT.ingestion.service;
 import com.iot.IoT.control.ControlDecisionEngine;
 import com.iot.IoT.ingestion.dto.DeviceState;
 import com.iot.IoT.ingestion.dto.DeviceStatusMessage;
+import com.iot.IoT.ingestion.metrics.IngestionMetricsCollector;
 import com.iot.IoT.ingestion.port.HeartbeatPort;
 import com.iot.IoT.ingestion.port.TemperatureTimeSeriesPort;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +24,7 @@ class DeviceIngestionServiceImplTest {
     private TemperatureTimeSeriesPort temperatureTimeSeriesPort;
     private HeartbeatPort heartbeatPort;
     private ControlDecisionEngine controlDecisionEngine;
+    private IngestionMetricsCollector ingestionMetricsCollector;
     private DeviceIngestionServiceImpl service;
 
     @BeforeEach
@@ -30,7 +32,13 @@ class DeviceIngestionServiceImplTest {
         temperatureTimeSeriesPort = Mockito.mock(TemperatureTimeSeriesPort.class);
         heartbeatPort = Mockito.mock(HeartbeatPort.class);
         controlDecisionEngine = Mockito.mock(ControlDecisionEngine.class);
-        service = new DeviceIngestionServiceImpl(temperatureTimeSeriesPort, heartbeatPort, controlDecisionEngine);
+        ingestionMetricsCollector = Mockito.mock(IngestionMetricsCollector.class);
+        service = new DeviceIngestionServiceImpl(
+                temperatureTimeSeriesPort,
+                heartbeatPort,
+                controlDecisionEngine,
+                ingestionMetricsCollector
+        );
     }
 
     @Test
@@ -42,6 +50,10 @@ class DeviceIngestionServiceImplTest {
 
         verify(temperatureTimeSeriesPort, times(1)).save(eq(message), any());
         verify(heartbeatPort, times(1)).updateLastSeen(eq("SV-001"), any());
+        verify(ingestionMetricsCollector, times(1)).recordInfluxSuccess();
+        verify(ingestionMetricsCollector, times(0)).recordInfluxFailure();
+        verify(ingestionMetricsCollector, times(1)).recordRedisSuccess();
+        verify(ingestionMetricsCollector, times(0)).recordRedisFailure();
     }
 
     @Test
@@ -54,6 +66,10 @@ class DeviceIngestionServiceImplTest {
 
         verify(temperatureTimeSeriesPort, times(1)).save(eq(message), any());
         verify(heartbeatPort, times(1)).updateLastSeen(eq("SV-001"), any());
+        verify(ingestionMetricsCollector, times(0)).recordInfluxSuccess();
+        verify(ingestionMetricsCollector, times(1)).recordInfluxFailure();
+        verify(ingestionMetricsCollector, times(1)).recordRedisSuccess();
+        verify(ingestionMetricsCollector, times(0)).recordRedisFailure();
     }
 
     @Test
@@ -66,6 +82,10 @@ class DeviceIngestionServiceImplTest {
 
         verify(temperatureTimeSeriesPort, times(1)).save(eq(message), any());
         verify(heartbeatPort, times(1)).updateLastSeen(eq("SV-001"), any());
+        verify(ingestionMetricsCollector, times(1)).recordInfluxSuccess();
+        verify(ingestionMetricsCollector, times(0)).recordInfluxFailure();
+        verify(ingestionMetricsCollector, times(0)).recordRedisSuccess();
+        verify(ingestionMetricsCollector, times(1)).recordRedisFailure();
     }
 
     private DeviceStatusMessage sampleMessage() {


### PR DESCRIPTION
## Summary                                                                                                      
  - 변경 배경:                                                                                                    
    - 5k/10k 부하 테스트에서 Ingestion 병목 지점을 분리 식별할 관측 지표가 필요함.                                
  - 핵심 변경사항:                                                                                                
    - `IngestionMetricsCollector` 신규 추가                                                                       
    - MQTT 수신/파싱 성공·실패, Influx 성공·실패, Redis 성공·실패 카운터 추가                                     
    - 1초 주기 델타/누적 메트릭 로그(`[INGEST-METRICS/1s]`) 출력                                                  
    - `DeviceIngestionServiceImplTest`에 메트릭 호출 검증 추가                                                    
    - 설정값 추가:                                                                                                
      - `ingestion.metrics.enabled`                                                                               
      - `ingestion.metrics-log-interval-ms`                                                                       
  - Closes: #17                                                                                             
                                                                                                                  
  ## Why                                                                                                          
  - 이 변경이 필요한 이유:                                                                                        
    - 기존에는 연결/발행 성공 여부만 확인 가능했고, 앱 내부 파이프라인(파싱/저장) 단계별 실패율을 정량적으로 볼 수
  없었기 때문.                                                                                                    
                                                                                                                  
  ## Changes                                                                                                      
  - [x] Ingestion                                                                                                 
  - [ ] Control Loop                                                                                              
  - [ ] Watchdog/Fail-safe                                                                                        
  - [x] Infra/Config                                                                                              
  - [ ] Docs                                                                                                      
                                                                                                                  
  ## Test Evidence                                                                                                
  - 실행 커맨드:
    - `./gradlew test --tests "com.iot.IoT.ingestion.service.DeviceIngestionServiceImplTest"`                     
    - `./gradlew test --tests "com.iot.IoT.ingestion.parser.MqttPayloadParserTest"`                               
  - 결과 요약:                                                                                                    
    - 두 테스트 모두 `BUILD SUCCESSFUL`                                                                           
  - 로그/스크린샷:                                                                                                
    - 로컬 실행 로그 첨부                                                                                         
                                                                                                                  
  ## Risk & Rollback                                                                                              
  - 예상 리스크:                                                                                                  
    - 고부하 구간에서 메트릭 로그량 증가 가능                                                                     
  - 롤백 방법:                                                                                                    
    - `ingestion.metrics.enabled=false`로 즉시 비활성화                                                           
    - 필요 시 해당 커밋 revert                                                                                    
                                                                                                                  
  ## Checklist                                                                                                    
  - [x] 관련 이슈 링크를 연결했다.                                                                                
  - [x] 예외/에러 처리 경로를 점검했다.                                                                           
  - [x] 테스트를 추가/갱신했다.                                                                                   
  - [x] 성능 영향(고트래픽 관점)을 검토했다.                                                                      