### PR TITLE
feat(ingestion): isolate influx bottleneck for 10k hive validation

### DIFF
--- a/docs/load-test-results.md
+++ b/docs/load-test-results.md
@@ -139,6 +139,18 @@ Source artifacts:
 - `docs/loadtest-runs/<run-id>/attempt-<n>/connection-summary.json`
 - `docs/loadtest-runs/<run-id>/attempt-<n>/business-summary.json`
 
-| Run ID | Attempt | Command | Connection Published | Connection Failed | Connection Success(%) | Connection Throughput(msg/s) | Business recv | Business pipeline success | Business Success(%) | Parse Fail | Influx Fail | Redis Fail | Notes |
-|---|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
-| `<run-id>` | `<n>` | `SIM_TASK=mqttLoadTestHive RUN_ID=<run-id> ... ./scripts/loadtest/run-distributed.sh 5000 5 120 1 60 1` | `<published_total>` | `<failed_total>` | `<success_rate_pct>` | `<throughput_total_msg_per_sec>` | `<recv_total>` | `<pipeline_success_total>` | `<pipeline_success_rate_pct>` | `<parse_fail_total>` | `<influx_fail_total>` | `<redis_fail_total>` | `PR1` |
+| Run ID | Attempt | Command | Connection Published | Connection Failed | Connection Success(%) | Connection Throughput(msg/s) | Business recv | Business overall pipeline success | Business overall Success(%) | Business core pipeline success | Business core Success(%) | Parse Fail | Influx Fail | Influx Bypass | Redis Fail | Notes |
+|---|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| `pr1-5k-20260219-113748` | `1` | `SIM_TASK=mqttLoadTestHive RUN_ID=pr1-5k-20260219-113748 MAX_ATTEMPTS=1 PART_TIMEOUT_SECONDS=540 ./scripts/loadtest/run-distributed.sh 5000 5 120 1 60 1` | `305000` | `0` | `100.00` | `5083.35` | `680` | `0` | `0.00` | `0` | `0.00` | `0` | `680` | `0` | `0` | `PR1 measured (strict mode, Influx write path failed)` |
+
+Formulas:
+- overall pipeline success = `min(parse_ok_total, influx_ok_total, redis_ok_total) / recv_total`
+- core pipeline success = `min(parse_ok_total, redis_ok_total) / recv_total`
+
+## Phase F PR2 Runbook (HiveMQ 10k, bypass mode)
+```bash
+# Backend must run with ingestion.influx.write-mode=bypass
+SIM_TASK=mqttLoadTestHive RUN_ID="pr2-hive-10k-$(date +%Y%m%d-%H%M%S)" MAX_ATTEMPTS=1 PART_TIMEOUT_SECONDS=780 REQUIRE_BUSINESS_SUMMARY=1 ./scripts/loadtest/run-distributed.sh 10000 8 120 1 60 1
+```
+
+Use the same split-table schema above for PR2 rows, with `Influx Bypass` and `Business core pipeline success` as required columns.

--- a/scripts/loadtest/summarize-ingestion-metrics.sh
+++ b/scripts/loadtest/summarize-ingestion-metrics.sh
@@ -28,7 +28,7 @@ if [[ -z "$METRICS_LINE" ]]; then
   echo "No [INGEST-METRICS/1s] totals line found in: $BACKEND_LOG" >&2
   exit 1
 fi
-TOTALS_SEGMENT="$(echo "$METRICS_LINE" | sed -E 's/^.*\|[[:space:]]*totals[[:space:]]*//')"
+TOTALS_SEGMENT="$(echo "$METRICS_LINE" | sed -E 's/^.*\|[[:space:]]*totals[[:space:]]*//' | tr ',' ' ')"
 
 extract_total() {
   local key="$1"
@@ -48,6 +48,21 @@ extract_total() {
   echo "$value"
 }
 
+extract_total_optional() {
+  local key="$1"
+  local segment="$2"
+  local default_value="$3"
+  local value
+
+  value="$(extract_total "$key" "$segment" || true)"
+  if [[ -z "$value" ]]; then
+    echo "$default_value"
+    return 0
+  fi
+
+  echo "$value"
+}
+
 if ! RECV_TOTAL="$(extract_total "recv" "$TOTALS_SEGMENT")" \
   || ! PARSE_OK_TOTAL="$(extract_total "parseOk" "$TOTALS_SEGMENT")" \
   || ! PARSE_FAIL_TOTAL="$(extract_total "parseFail" "$TOTALS_SEGMENT")" \
@@ -58,6 +73,8 @@ if ! RECV_TOTAL="$(extract_total "recv" "$TOTALS_SEGMENT")" \
   echo "Failed to parse totals from backend log line: $METRICS_LINE" >&2
   exit 1
 fi
+
+INFLUX_BYPASS_TOTAL="$(extract_total_optional "influxBypass" "$TOTALS_SEGMENT" "0")"
 
 PIPELINE_SUCCESS_TOTAL="$PARSE_OK_TOTAL"
 if (( INFLUX_OK_TOTAL < PIPELINE_SUCCESS_TOTAL )); then
@@ -75,6 +92,19 @@ fi
 PIPELINE_SUCCESS_RATE="$(awk -v ok="$PIPELINE_SUCCESS_TOTAL" -v recv="$RECV_TOTAL" 'BEGIN { if (recv == 0) { printf "0.0000" } else { printf "%.4f", ok / recv } }')"
 PIPELINE_SUCCESS_RATE_PCT="$(awk -v r="$PIPELINE_SUCCESS_RATE" 'BEGIN { printf "%.2f", r * 100 }')"
 
+CORE_PIPELINE_SUCCESS_TOTAL="$PARSE_OK_TOTAL"
+if (( REDIS_OK_TOTAL < CORE_PIPELINE_SUCCESS_TOTAL )); then
+  CORE_PIPELINE_SUCCESS_TOTAL="$REDIS_OK_TOTAL"
+fi
+
+CORE_PIPELINE_FAILURE_TOTAL=$(( RECV_TOTAL - CORE_PIPELINE_SUCCESS_TOTAL ))
+if (( CORE_PIPELINE_FAILURE_TOTAL < 0 )); then
+  CORE_PIPELINE_FAILURE_TOTAL=0
+fi
+
+CORE_PIPELINE_SUCCESS_RATE="$(awk -v ok="$CORE_PIPELINE_SUCCESS_TOTAL" -v recv="$RECV_TOTAL" 'BEGIN { if (recv == 0) { printf "0.0000" } else { printf "%.4f", ok / recv } }')"
+CORE_PIPELINE_SUCCESS_RATE_PCT="$(awk -v r="$CORE_PIPELINE_SUCCESS_RATE" 'BEGIN { printf "%.2f", r * 100 }')"
+
 cat > "$SUMMARY_FILE" <<EOF
 {
   "run_id": "${RUN_ID}",
@@ -84,17 +114,25 @@ cat > "$SUMMARY_FILE" <<EOF
   "parse_fail_total": ${PARSE_FAIL_TOTAL},
   "influx_ok_total": ${INFLUX_OK_TOTAL},
   "influx_fail_total": ${INFLUX_FAIL_TOTAL},
+  "influx_bypass_total": ${INFLUX_BYPASS_TOTAL},
   "redis_ok_total": ${REDIS_OK_TOTAL},
   "redis_fail_total": ${REDIS_FAIL_TOTAL},
   "pipeline_success_total": ${PIPELINE_SUCCESS_TOTAL},
   "pipeline_failure_total": ${PIPELINE_FAILURE_TOTAL},
   "pipeline_success_rate": ${PIPELINE_SUCCESS_RATE},
   "pipeline_success_rate_pct": ${PIPELINE_SUCCESS_RATE_PCT},
-  "pipeline_success_formula": "min(parse_ok_total, influx_ok_total, redis_ok_total) / recv_total"
+  "pipeline_success_formula": "min(parse_ok_total, influx_ok_total, redis_ok_total) / recv_total",
+  "core_pipeline_success_total": ${CORE_PIPELINE_SUCCESS_TOTAL},
+  "core_pipeline_failure_total": ${CORE_PIPELINE_FAILURE_TOTAL},
+  "core_pipeline_success_rate": ${CORE_PIPELINE_SUCCESS_RATE},
+  "core_pipeline_success_rate_pct": ${CORE_PIPELINE_SUCCESS_RATE_PCT},
+  "core_pipeline_success_formula": "min(parse_ok_total, redis_ok_total) / recv_total"
 }
 EOF
 
 echo "[DIST] business recv_total=${RECV_TOTAL}"
 echo "[DIST] business pipeline_success_total=${PIPELINE_SUCCESS_TOTAL}"
 echo "[DIST] business pipeline_success_rate=${PIPELINE_SUCCESS_RATE_PCT}%"
+echo "[DIST] business core_pipeline_success_total=${CORE_PIPELINE_SUCCESS_TOTAL}"
+echo "[DIST] business core_pipeline_success_rate=${CORE_PIPELINE_SUCCESS_RATE_PCT}%"
 echo "[DIST] business_summary=${SUMMARY_FILE}"

--- a/src/main/java/com/iot/IoT/ingestion/metrics/IngestionMetricsCollector.java
+++ b/src/main/java/com/iot/IoT/ingestion/metrics/IngestionMetricsCollector.java
@@ -20,6 +20,7 @@ public class IngestionMetricsCollector {
     private final LongAdder parseFailureTotal = new LongAdder();
     private final LongAdder influxSuccessTotal = new LongAdder();
     private final LongAdder influxFailureTotal = new LongAdder();
+    private final LongAdder influxBypassTotal = new LongAdder();
     private final LongAdder redisSuccessTotal = new LongAdder();
     private final LongAdder redisFailureTotal = new LongAdder();
 
@@ -28,6 +29,7 @@ public class IngestionMetricsCollector {
     private final AtomicLong lastParseFailure = new AtomicLong(0);
     private final AtomicLong lastInfluxSuccess = new AtomicLong(0);
     private final AtomicLong lastInfluxFailure = new AtomicLong(0);
+    private final AtomicLong lastInfluxBypass = new AtomicLong(0);
     private final AtomicLong lastRedisSuccess = new AtomicLong(0);
     private final AtomicLong lastRedisFailure = new AtomicLong(0);
 
@@ -51,6 +53,10 @@ public class IngestionMetricsCollector {
         influxFailureTotal.increment();
     }
 
+    public void recordInfluxBypass() {
+        influxBypassTotal.increment();
+    }
+
     public void recordRedisSuccess() {
         redisSuccessTotal.increment();
     }
@@ -66,6 +72,7 @@ public class IngestionMetricsCollector {
         long parseFailure = parseFailureTotal.sum();
         long influxSuccess = influxSuccessTotal.sum();
         long influxFailure = influxFailureTotal.sum();
+        long influxBypass = influxBypassTotal.sum();
         long redisSuccess = redisSuccessTotal.sum();
         long redisFailure = redisFailureTotal.sum();
 
@@ -74,6 +81,7 @@ public class IngestionMetricsCollector {
         long parseFailureDelta = parseFailure - lastParseFailure.getAndSet(parseFailure);
         long influxSuccessDelta = influxSuccess - lastInfluxSuccess.getAndSet(influxSuccess);
         long influxFailureDelta = influxFailure - lastInfluxFailure.getAndSet(influxFailure);
+        long influxBypassDelta = influxBypass - lastInfluxBypass.getAndSet(influxBypass);
         long redisSuccessDelta = redisSuccess - lastRedisSuccess.getAndSet(redisSuccess);
         long redisFailureDelta = redisFailure - lastRedisFailure.getAndSet(redisFailure);
 
@@ -82,17 +90,19 @@ public class IngestionMetricsCollector {
                 && parseFailureDelta == 0
                 && influxSuccessDelta == 0
                 && influxFailureDelta == 0
+                && influxBypassDelta == 0
                 && redisSuccessDelta == 0
                 && redisFailureDelta == 0) {
             return;
         }
 
-        log.info("[INGEST-METRICS/1s] recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, redisOk={}, redisFail={} | totals recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, redisOk={}, redisFail={}",
+        log.info("[INGEST-METRICS/1s] recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, influxBypass={}, redisOk={}, redisFail={} | totals recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, influxBypass={}, redisOk={}, redisFail={}",
                 mqttReceivedDelta,
                 parseSuccessDelta,
                 parseFailureDelta,
                 influxSuccessDelta,
                 influxFailureDelta,
+                influxBypassDelta,
                 redisSuccessDelta,
                 redisFailureDelta,
                 mqttReceived,
@@ -100,6 +110,7 @@ public class IngestionMetricsCollector {
                 parseFailure,
                 influxSuccess,
                 influxFailure,
+                influxBypass,
                 redisSuccess,
                 redisFailure);
     }

--- a/src/main/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImpl.java
+++ b/src/main/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImpl.java
@@ -8,6 +8,7 @@ import com.iot.IoT.ingestion.port.HeartbeatPort;
 import com.iot.IoT.ingestion.port.TemperatureTimeSeriesPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -16,39 +17,47 @@ import java.time.Instant;
 public class DeviceIngestionServiceImpl implements DeviceIngestionService {
 
     private static final Logger log = LoggerFactory.getLogger(DeviceIngestionServiceImpl.class);
+    private static final String INFLUX_WRITE_MODE_BYPASS = "bypass";
 
     private final TemperatureTimeSeriesPort temperatureTimeSeriesPort;
     private final HeartbeatPort heartbeatPort;
     private final ControlDecisionEngine controlDecisionEngine;
     private final IngestionMetricsCollector ingestionMetricsCollector;
+    private final String influxWriteMode;
 
     public DeviceIngestionServiceImpl(
             TemperatureTimeSeriesPort temperatureTimeSeriesPort,
             HeartbeatPort heartbeatPort,
             ControlDecisionEngine controlDecisionEngine,
-            IngestionMetricsCollector ingestionMetricsCollector
+            IngestionMetricsCollector ingestionMetricsCollector,
+            @Value("${ingestion.influx.write-mode:strict}") String influxWriteMode
     ) {
         this.temperatureTimeSeriesPort = temperatureTimeSeriesPort;
         this.heartbeatPort = heartbeatPort;
         this.controlDecisionEngine = controlDecisionEngine;
         this.ingestionMetricsCollector = ingestionMetricsCollector;
+        this.influxWriteMode = influxWriteMode;
     }
 
     @Override
     public void ingest(DeviceStatusMessage message) {
         Instant now = Instant.now();
 
-        try {
-            temperatureTimeSeriesPort.save(message, now);
-            ingestionMetricsCollector.recordInfluxSuccess();
-        } catch (Exception e) {
-            ingestionMetricsCollector.recordInfluxFailure();
-            log.error("[INGESTION] Influx write failed. deviceId={}, temp={}, targetTemp={}, state={}",
-                    message.deviceId(),
-                    message.temp(),
-                    message.targetTemp(),
-                    message.state(),
-                    e);
+        if (isInfluxWriteBypassMode()) {
+            ingestionMetricsCollector.recordInfluxBypass();
+        } else {
+            try {
+                temperatureTimeSeriesPort.save(message, now);
+                ingestionMetricsCollector.recordInfluxSuccess();
+            } catch (Exception e) {
+                ingestionMetricsCollector.recordInfluxFailure();
+                log.error("[INGESTION] Influx write failed. deviceId={}, temp={}, targetTemp={}, state={}",
+                        message.deviceId(),
+                        message.temp(),
+                        message.targetTemp(),
+                        message.state(),
+                        e);
+            }
         }
 
         try {
@@ -66,5 +75,9 @@ public class DeviceIngestionServiceImpl implements DeviceIngestionService {
                 message.targetTemp(),
                 message.state(),
                 action);
+    }
+
+    private boolean isInfluxWriteBypassMode() {
+        return INFLUX_WRITE_MODE_BYPASS.equalsIgnoreCase(influxWriteMode);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,8 @@ influxdb:
 
 ingestion:
   heartbeat-ttl-seconds: 120
+  influx:
+    write-mode: strict
   metrics:
     enabled: true
   metrics-log-interval-ms: 1000

--- a/src/test/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImplTest.java
+++ b/src/test/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImplTest.java
@@ -16,10 +16,14 @@ import java.math.BigDecimal;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 class DeviceIngestionServiceImplTest {
+
+    private static final String INFLUX_MODE_STRICT = "strict";
+    private static final String INFLUX_MODE_BYPASS = "bypass";
 
     private TemperatureTimeSeriesPort temperatureTimeSeriesPort;
     private HeartbeatPort heartbeatPort;
@@ -33,12 +37,7 @@ class DeviceIngestionServiceImplTest {
         heartbeatPort = Mockito.mock(HeartbeatPort.class);
         controlDecisionEngine = Mockito.mock(ControlDecisionEngine.class);
         ingestionMetricsCollector = Mockito.mock(IngestionMetricsCollector.class);
-        service = new DeviceIngestionServiceImpl(
-                temperatureTimeSeriesPort,
-                heartbeatPort,
-                controlDecisionEngine,
-                ingestionMetricsCollector
-        );
+        service = createService(INFLUX_MODE_STRICT);
     }
 
     @Test
@@ -54,6 +53,7 @@ class DeviceIngestionServiceImplTest {
         verify(ingestionMetricsCollector, times(0)).recordInfluxFailure();
         verify(ingestionMetricsCollector, times(1)).recordRedisSuccess();
         verify(ingestionMetricsCollector, times(0)).recordRedisFailure();
+        verify(controlDecisionEngine, times(1)).decide(eq(message));
     }
 
     @Test
@@ -70,6 +70,7 @@ class DeviceIngestionServiceImplTest {
         verify(ingestionMetricsCollector, times(1)).recordInfluxFailure();
         verify(ingestionMetricsCollector, times(1)).recordRedisSuccess();
         verify(ingestionMetricsCollector, times(0)).recordRedisFailure();
+        verify(controlDecisionEngine, times(1)).decide(eq(message));
     }
 
     @Test
@@ -86,6 +87,44 @@ class DeviceIngestionServiceImplTest {
         verify(ingestionMetricsCollector, times(0)).recordInfluxFailure();
         verify(ingestionMetricsCollector, times(0)).recordRedisSuccess();
         verify(ingestionMetricsCollector, times(1)).recordRedisFailure();
+        verify(controlDecisionEngine, times(1)).decide(eq(message));
+    }
+
+    @Test
+    @DisplayName("Should bypass Influx write but still update Redis and control")
+    void ingest_bypassMode_skipsInfluxButRunsRedisAndControl() {
+        service = createService(INFLUX_MODE_BYPASS);
+        DeviceStatusMessage message = sampleMessage();
+
+        service.ingest(message);
+
+        verify(temperatureTimeSeriesPort, never()).save(any(), any());
+        verify(heartbeatPort, times(1)).updateLastSeen(eq("SV-001"), any());
+        verify(ingestionMetricsCollector, times(1)).recordInfluxBypass();
+        verify(ingestionMetricsCollector, never()).recordInfluxSuccess();
+        verify(ingestionMetricsCollector, never()).recordInfluxFailure();
+        verify(ingestionMetricsCollector, times(1)).recordRedisSuccess();
+        verify(ingestionMetricsCollector, never()).recordRedisFailure();
+        verify(controlDecisionEngine, times(1)).decide(eq(message));
+    }
+
+    @Test
+    @DisplayName("Should treat bypass mode case-insensitively and still run control when Redis fails")
+    void ingest_bypassModeCaseInsensitive_redisFails_controlStillRuns() {
+        service = createService("ByPaSs");
+        DeviceStatusMessage message = sampleMessage();
+        doThrow(new RuntimeException("redis down")).when(heartbeatPort).updateLastSeen(eq("SV-001"), any());
+
+        service.ingest(message);
+
+        verify(temperatureTimeSeriesPort, never()).save(any(), any());
+        verify(heartbeatPort, times(1)).updateLastSeen(eq("SV-001"), any());
+        verify(ingestionMetricsCollector, times(1)).recordInfluxBypass();
+        verify(ingestionMetricsCollector, never()).recordInfluxSuccess();
+        verify(ingestionMetricsCollector, never()).recordInfluxFailure();
+        verify(ingestionMetricsCollector, never()).recordRedisSuccess();
+        verify(ingestionMetricsCollector, times(1)).recordRedisFailure();
+        verify(controlDecisionEngine, times(1)).decide(eq(message));
     }
 
     private DeviceStatusMessage sampleMessage() {
@@ -94,6 +133,16 @@ class DeviceIngestionServiceImplTest {
                 new BigDecimal("60.5"),
                 DeviceState.HEATING,
                 new BigDecimal("65.0")
+        );
+    }
+
+    private DeviceIngestionServiceImpl createService(String influxWriteMode) {
+        return new DeviceIngestionServiceImpl(
+                temperatureTimeSeriesPort,
+                heartbeatPort,
+                controlDecisionEngine,
+                ingestionMetricsCollector,
+                influxWriteMode
         );
     }
 }

--- a/tests/fixtures/loadtest/ingestion/core-pipeline-diff/backend.log
+++ b/tests/fixtures/loadtest/ingestion/core-pipeline-diff/backend.log
@@ -1,0 +1,1 @@
+2026-02-18 00:00:00 [INGEST-METRICS/1s] window recv=50 parseOk=48 parseFail=2 influxOk=30 influxFail=20 influxBypass=5 redisOk=45 redisFail=5 | totals recv=300 parseOk=280 parseFail=20 influxOk=200 influxFail=100 influxBypass=15 redisOk=250 redisFail=50


### PR DESCRIPTION
## Summary
- #20 목적에 맞춰 HiveMQ 10k 검증 경로에서 Influx 병목을 분리 관측할 수 있도록 ingestion metrics/요약/문서를 확장했습니다.
- 핵심 변경:
  - `ingestion.influx.write-mode` (`strict|bypass`) 추가
  - `[INGEST-METRICS/1s]`에 `influxBypass` 계측 추가
  - `summarize-ingestion-metrics.sh`에 overall/core pipeline 성공률 동시 산출 추가
  - PR2 10k runbook 및 결과표 스키마 확장
  - bypass/요약 호환성 테스트 보강
- Closes: #20

## Why
- PR1 5k 실측에서 connection 성공률 100% 대비 Influx write 실패로 business 해석이 왜곡되었습니다.
- PR2는 Influx 의존 경로와 core(parse+redis) 경로를 분리해 병목 원인 분류 정확도를 높입니다.

## Changes
- [x] Ingestion
- [ ] Control Loop
- [ ] Watchdog/Fail-safe
- [x] Infra/Config
- [x] Docs

## Test Evidence
- `bash tests/loadtest/test-summarizers.sh` 통과
- `DeviceIngestionServiceImplTest`에 bypass 동작 검증 케이스 추가

## Risk & Rollback
- 리스크: metrics 필드 확장에 따른 후처리 스크립트/대시보드 파서 영향 가능
- 롤백: `git revert cb8bd426846cda8d32cf564abf637e171d827b72`

## Rollout Notes
1. backend를 `ingestion.influx.write-mode=bypass`로 설정
2. 10k dry-run 실행 후 `connection-summary.json` + `business-summary.json` 점검
3. core/overall 수치 비교로 Influx 병목 분리 확인

## Checklist
- [x] 관련 이슈 링크를 연결했다.
- [x] 예외/에러 처리 경로를 점검했다.
- [x] 테스트를 추가/갱신했다.
- [x] 성능 영향(고트래픽 관점)을 검토했다.
