### PR TITLE
 feat(device): add downlink command publish and history APIs

### DIFF
--- a/docs/device-api.md
+++ b/docs/device-api.md
@@ -135,6 +135,45 @@
   - `404 Not Found`
   - `400 Bad Request` (유효성 실패)
 
+### 9) POST /devices/{id}/commands
+- 설명: 디바이스로 다운링크 명령을 발행하고 이력을 저장한다.
+- Request body:
+```json
+{
+  "commandType": "HEAT_ON"
+}
+```
+- Rules:
+  - `commandType`: required (`HEAT_ON`, `HEAT_OFF`, `HOLD`)
+- Response example:
+```json
+{
+  "commandId": 10,
+  "devicePk": 1,
+  "deviceId": "SV-001",
+  "commandType": "HEAT_ON",
+  "status": "SENT",
+  "topic": "devices/SV-001/cmd",
+  "payload": "{\"commandId\":10,\"commandType\":\"HEAT_ON\",\"requestedAt\":\"2026-03-02T00:00:00Z\"}",
+  "requestedAt": "2026-03-02T00:00:00Z",
+  "sentAt": "2026-03-02T00:00:01Z",
+  "errorMessage": null
+}
+```
+- Responses:
+  - `200 OK` (`SENT` 또는 `FAILED`)
+  - `404 Not Found`
+  - `400 Bad Request`
+
+### 10) GET /devices/{id}/commands?limit={n}
+- 설명: 디바이스 다운링크 명령 이력을 조회한다.
+- Query params:
+  - `limit` optional (기본: `20`, 허용 범위 `1..100`)
+- Responses:
+  - `200 OK`
+  - `404 Not Found`
+  - `400 Bad Request` (invalid `limit`)
+
 ## Error Response Contract
 ```json
 {

--- a/src/main/java/com/iot/IoT/controller/DeviceController.java
+++ b/src/main/java/com/iot/IoT/controller/DeviceController.java
@@ -1,11 +1,14 @@
 package com.iot.IoT.controller;
 
 import com.iot.IoT.dto.CreateDeviceRequest;
+import com.iot.IoT.dto.DeviceCommandPageResponse;
+import com.iot.IoT.dto.DeviceCommandResponse;
 import com.iot.IoT.dto.DeviceControlPolicyResponse;
 import com.iot.IoT.dto.DevicePageResponse;
 import com.iot.IoT.dto.DeviceResponse;
 import com.iot.IoT.dto.DeviceStatusResponse;
 import com.iot.IoT.dto.DeviceTemperatureSeriesResponse;
+import com.iot.IoT.dto.SendDeviceCommandRequest;
 import com.iot.IoT.dto.UpdateDeviceControlPolicyRequest;
 import com.iot.IoT.dto.UpdateDeviceEnabledRequest;
 import com.iot.IoT.service.DeviceService;
@@ -91,5 +94,21 @@ public class DeviceController {
             @Valid @RequestBody UpdateDeviceControlPolicyRequest request
     ) {
         return deviceService.updateControlPolicy(id, request.targetTemp(), request.hysteresis());
+    }
+
+    @PostMapping("/{id}/commands")
+    public DeviceCommandResponse sendCommand(
+            @PathVariable Long id,
+            @Valid @RequestBody SendDeviceCommandRequest request
+    ) {
+        return deviceService.sendCommand(id, request.commandType());
+    }
+
+    @GetMapping("/{id}/commands")
+    public DeviceCommandPageResponse getCommands(
+            @PathVariable Long id,
+            @RequestParam(defaultValue = "0") int limit
+    ) {
+        return deviceService.getCommands(id, limit);
     }
 }

--- a/src/main/java/com/iot/IoT/dto/DeviceCommandPageResponse.java
+++ b/src/main/java/com/iot/IoT/dto/DeviceCommandPageResponse.java
@@ -1,0 +1,11 @@
+package com.iot.IoT.dto;
+
+import java.util.List;
+
+public record DeviceCommandPageResponse(
+        Long devicePk,
+        String deviceId,
+        int limit,
+        List<DeviceCommandResponse> items
+) {
+}

--- a/src/main/java/com/iot/IoT/dto/DeviceCommandResponse.java
+++ b/src/main/java/com/iot/IoT/dto/DeviceCommandResponse.java
@@ -1,0 +1,20 @@
+package com.iot.IoT.dto;
+
+import com.iot.IoT.control.ControlAction;
+import com.iot.IoT.entity.DeviceCommandStatus;
+
+import java.time.Instant;
+
+public record DeviceCommandResponse(
+        Long commandId,
+        Long devicePk,
+        String deviceId,
+        ControlAction commandType,
+        DeviceCommandStatus status,
+        String topic,
+        String payload,
+        Instant requestedAt,
+        Instant sentAt,
+        String errorMessage
+) {
+}

--- a/src/main/java/com/iot/IoT/dto/SendDeviceCommandRequest.java
+++ b/src/main/java/com/iot/IoT/dto/SendDeviceCommandRequest.java
@@ -1,0 +1,9 @@
+package com.iot.IoT.dto;
+
+import com.iot.IoT.control.ControlAction;
+import jakarta.validation.constraints.NotNull;
+
+public record SendDeviceCommandRequest(
+        @NotNull ControlAction commandType
+) {
+}

--- a/src/main/java/com/iot/IoT/entity/DeviceCommand.java
+++ b/src/main/java/com/iot/IoT/entity/DeviceCommand.java
@@ -1,0 +1,135 @@
+package com.iot.IoT.entity;
+
+import com.iot.IoT.control.ControlAction;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "device_commands")
+public class DeviceCommand {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "device_pk", nullable = false)
+    private Long devicePk;
+
+    @Column(name = "device_id", nullable = false, length = 64)
+    private String deviceId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "command_type", nullable = false, length = 32)
+    private ControlAction commandType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private DeviceCommandStatus status;
+
+    @Column(name = "topic", nullable = false, length = 128)
+    private String topic;
+
+    @Column(name = "payload", nullable = false, length = 1000)
+    private String payload;
+
+    @Column(name = "requested_at", nullable = false, updatable = false)
+    private Instant requestedAt;
+
+    @Column(name = "sent_at")
+    private Instant sentAt;
+
+    @Column(name = "error_message", length = 500)
+    private String errorMessage;
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getDevicePk() {
+        return devicePk;
+    }
+
+    public void setDevicePk(Long devicePk) {
+        this.devicePk = devicePk;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    public void setDeviceId(String deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    public ControlAction getCommandType() {
+        return commandType;
+    }
+
+    public void setCommandType(ControlAction commandType) {
+        this.commandType = commandType;
+    }
+
+    public DeviceCommandStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(DeviceCommandStatus status) {
+        this.status = status;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+
+    public Instant getRequestedAt() {
+        return requestedAt;
+    }
+
+    public void setRequestedAt(Instant requestedAt) {
+        this.requestedAt = requestedAt;
+    }
+
+    public Instant getSentAt() {
+        return sentAt;
+    }
+
+    public void setSentAt(Instant sentAt) {
+        this.sentAt = sentAt;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    @PrePersist
+    void onCreate() {
+        if (this.requestedAt == null) {
+            this.requestedAt = Instant.now();
+        }
+    }
+}

--- a/src/main/java/com/iot/IoT/entity/DeviceCommandStatus.java
+++ b/src/main/java/com/iot/IoT/entity/DeviceCommandStatus.java
@@ -1,0 +1,7 @@
+package com.iot.IoT.entity;
+
+public enum DeviceCommandStatus {
+    PENDING,
+    SENT,
+    FAILED
+}

--- a/src/main/java/com/iot/IoT/mqtt/adapter/MqttDeviceCommandPublisherAdapter.java
+++ b/src/main/java/com/iot/IoT/mqtt/adapter/MqttDeviceCommandPublisherAdapter.java
@@ -1,0 +1,56 @@
+package com.iot.IoT.mqtt.adapter;
+
+import com.iot.IoT.mqtt.port.DeviceCommandPublisherPort;
+import com.iot.IoT.service.exception.DeviceCommandPublishException;
+import org.eclipse.paho.client.mqttv3.IMqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.integration.mqtt.core.MqttPahoClientFactory;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class MqttDeviceCommandPublisherAdapter implements DeviceCommandPublisherPort {
+
+    private static final int QOS = 1;
+    private static final long TIMEOUT_MS = 5_000L;
+
+    private final MqttPahoClientFactory mqttClientFactory;
+    private final String brokerUrl;
+    private final String publisherClientId;
+    private IMqttAsyncClient client;
+
+    public MqttDeviceCommandPublisherAdapter(
+            MqttPahoClientFactory mqttClientFactory,
+            @Value("${spring.mqtt.broker-url}") String brokerUrl,
+            @Value("${spring.mqtt.client-id}") String clientId
+    ) {
+        this.mqttClientFactory = mqttClientFactory;
+        this.brokerUrl = brokerUrl;
+        this.publisherClientId = clientId + "-downlink-publisher";
+    }
+
+    @Override
+    public synchronized void publish(String topic, String payload) {
+        try {
+            IMqttAsyncClient mqttClient = getConnectedClient();
+            MqttMessage message = new MqttMessage(payload.getBytes(StandardCharsets.UTF_8));
+            message.setQos(QOS);
+            mqttClient.publish(topic, message).waitForCompletion(TIMEOUT_MS);
+        } catch (MqttException ex) {
+            throw new DeviceCommandPublishException("MQTT publish failed. topic=" + topic, ex);
+        }
+    }
+
+    private IMqttAsyncClient getConnectedClient() throws MqttException {
+        if (client == null) {
+            client = mqttClientFactory.getAsyncClientInstance(brokerUrl, publisherClientId);
+        }
+        if (!client.isConnected()) {
+            client.connect().waitForCompletion(TIMEOUT_MS);
+        }
+        return client;
+    }
+}

--- a/src/main/java/com/iot/IoT/mqtt/port/DeviceCommandPublisherPort.java
+++ b/src/main/java/com/iot/IoT/mqtt/port/DeviceCommandPublisherPort.java
@@ -1,0 +1,6 @@
+package com.iot.IoT.mqtt.port;
+
+public interface DeviceCommandPublisherPort {
+
+    void publish(String topic, String payload);
+}

--- a/src/main/java/com/iot/IoT/repository/DeviceCommandRepository.java
+++ b/src/main/java/com/iot/IoT/repository/DeviceCommandRepository.java
@@ -1,0 +1,12 @@
+package com.iot.IoT.repository;
+
+import com.iot.IoT.entity.DeviceCommand;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DeviceCommandRepository extends JpaRepository<DeviceCommand, Long> {
+
+    List<DeviceCommand> findByDevicePkOrderByRequestedAtDesc(Long devicePk, Pageable pageable);
+}

--- a/src/main/java/com/iot/IoT/service/DeviceService.java
+++ b/src/main/java/com/iot/IoT/service/DeviceService.java
@@ -1,11 +1,14 @@
 package com.iot.IoT.service;
 
 import com.iot.IoT.dto.CreateDeviceRequest;
+import com.iot.IoT.dto.DeviceCommandPageResponse;
+import com.iot.IoT.dto.DeviceCommandResponse;
 import com.iot.IoT.dto.DeviceControlPolicyResponse;
 import com.iot.IoT.dto.DevicePageResponse;
 import com.iot.IoT.dto.DeviceResponse;
 import com.iot.IoT.dto.DeviceStatusResponse;
 import com.iot.IoT.dto.DeviceTemperatureSeriesResponse;
+import com.iot.IoT.control.ControlAction;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -27,4 +30,8 @@ public interface DeviceService {
     DeviceControlPolicyResponse getControlPolicy(Long id);
 
     DeviceControlPolicyResponse updateControlPolicy(Long id, BigDecimal targetTemp, BigDecimal hysteresis);
+
+    DeviceCommandResponse sendCommand(Long id, ControlAction commandType);
+
+    DeviceCommandPageResponse getCommands(Long id, int limit);
 }

--- a/src/main/java/com/iot/IoT/service/DeviceServiceImpl.java
+++ b/src/main/java/com/iot/IoT/service/DeviceServiceImpl.java
@@ -1,6 +1,9 @@
 package com.iot.IoT.service;
 
+import com.iot.IoT.control.ControlAction;
 import com.iot.IoT.dto.CreateDeviceRequest;
+import com.iot.IoT.dto.DeviceCommandPageResponse;
+import com.iot.IoT.dto.DeviceCommandResponse;
 import com.iot.IoT.dto.DeviceControlPolicyResponse;
 import com.iot.IoT.dto.DevicePageResponse;
 import com.iot.IoT.dto.DeviceResponse;
@@ -8,7 +11,11 @@ import com.iot.IoT.dto.DeviceStatusResponse;
 import com.iot.IoT.dto.DeviceTemperaturePointResponse;
 import com.iot.IoT.dto.DeviceTemperatureSeriesResponse;
 import com.iot.IoT.entity.Device;
+import com.iot.IoT.entity.DeviceCommand;
+import com.iot.IoT.entity.DeviceCommandStatus;
 import com.iot.IoT.ingestion.port.TemperatureTimeSeriesQueryPort;
+import com.iot.IoT.mqtt.port.DeviceCommandPublisherPort;
+import com.iot.IoT.repository.DeviceCommandRepository;
 import com.iot.IoT.repository.DeviceRepository;
 import com.iot.IoT.service.exception.DeviceNotFoundException;
 import com.iot.IoT.service.exception.DuplicateDeviceException;
@@ -35,22 +42,31 @@ public class DeviceServiceImpl implements DeviceService {
     private static final int MIN_TEMP_LIMIT = 1;
     private static final int MAX_TEMP_LIMIT = 500;
     private static final int DEFAULT_TEMP_LIMIT = 200;
+    private static final int DEFAULT_COMMAND_LIMIT = 20;
+    private static final int MIN_COMMAND_LIMIT = 1;
+    private static final int MAX_COMMAND_LIMIT = 100;
     private static final Duration DEFAULT_RANGE = Duration.ofHours(1);
 
     private final DeviceRepository deviceRepository;
+    private final DeviceCommandRepository deviceCommandRepository;
     private final WatchdogStatePort watchdogStatePort;
     private final TemperatureTimeSeriesQueryPort temperatureTimeSeriesQueryPort;
+    private final DeviceCommandPublisherPort deviceCommandPublisherPort;
     private final Duration heartbeatTtl;
 
     public DeviceServiceImpl(
             DeviceRepository deviceRepository,
+            DeviceCommandRepository deviceCommandRepository,
             WatchdogStatePort watchdogStatePort,
             TemperatureTimeSeriesQueryPort temperatureTimeSeriesQueryPort,
+            DeviceCommandPublisherPort deviceCommandPublisherPort,
             @Value("${ingestion.heartbeat-ttl-seconds:120}") long heartbeatTtlSeconds
     ) {
         this.deviceRepository = deviceRepository;
+        this.deviceCommandRepository = deviceCommandRepository;
         this.watchdogStatePort = watchdogStatePort;
         this.temperatureTimeSeriesQueryPort = temperatureTimeSeriesQueryPort;
+        this.deviceCommandPublisherPort = deviceCommandPublisherPort;
         this.heartbeatTtl = Duration.ofSeconds(heartbeatTtlSeconds);
     }
 
@@ -167,6 +183,58 @@ public class DeviceServiceImpl implements DeviceService {
         return toControlPolicyResponse(updated);
     }
 
+    @Override
+    @Transactional
+    public DeviceCommandResponse sendCommand(Long id, ControlAction commandType) {
+        Device device = findEntity(id);
+        String topic = buildCommandTopic(device.getDeviceId());
+
+        DeviceCommand command = new DeviceCommand();
+        command.setDevicePk(device.getId());
+        command.setDeviceId(device.getDeviceId());
+        command.setCommandType(commandType);
+        command.setStatus(DeviceCommandStatus.PENDING);
+        command.setTopic(topic);
+        command.setPayload("");
+
+        DeviceCommand created = deviceCommandRepository.save(command);
+        if (created.getId() == null) {
+            throw new IllegalStateException("Device command id was not generated");
+        }
+        Instant requestedAt = created.getRequestedAt() == null ? Instant.now() : created.getRequestedAt();
+        created.setRequestedAt(requestedAt);
+        String payload = buildCommandPayload(created.getId(), commandType, requestedAt);
+        created.setPayload(payload);
+
+        try {
+            deviceCommandPublisherPort.publish(topic, payload);
+            created.setStatus(DeviceCommandStatus.SENT);
+            created.setSentAt(Instant.now());
+            created.setErrorMessage(null);
+        } catch (RuntimeException ex) {
+            created.setStatus(DeviceCommandStatus.FAILED);
+            created.setSentAt(null);
+            created.setErrorMessage(ex.getMessage());
+        }
+
+        DeviceCommand saved = deviceCommandRepository.save(created);
+        return toCommandResponse(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public DeviceCommandPageResponse getCommands(Long id, int limit) {
+        Device device = findEntity(id);
+        int normalizedLimit = normalizeCommandLimit(limit);
+        List<DeviceCommandResponse> items = deviceCommandRepository.findByDevicePkOrderByRequestedAtDesc(
+                        device.getId(),
+                        PageRequest.of(0, normalizedLimit)
+                ).stream()
+                .map(this::toCommandResponse)
+                .toList();
+        return new DeviceCommandPageResponse(device.getId(), device.getDeviceId(), normalizedLimit, items);
+    }
+
     private Device findEntity(Long id) {
         return deviceRepository.findById(id)
                 .orElseThrow(() -> new DeviceNotFoundException(id));
@@ -190,6 +258,21 @@ public class DeviceServiceImpl implements DeviceService {
                 device.getControlTargetTemp(),
                 device.getControlHysteresis(),
                 device.getUpdatedAt()
+        );
+    }
+
+    private DeviceCommandResponse toCommandResponse(DeviceCommand command) {
+        return new DeviceCommandResponse(
+                command.getId(),
+                command.getDevicePk(),
+                command.getDeviceId(),
+                command.getCommandType(),
+                command.getStatus(),
+                command.getTopic(),
+                command.getPayload(),
+                command.getRequestedAt(),
+                command.getSentAt(),
+                command.getErrorMessage()
         );
     }
 
@@ -227,6 +310,28 @@ public class DeviceServiceImpl implements DeviceService {
             );
         }
         return limit;
+    }
+
+    private int normalizeCommandLimit(int limit) {
+        if (limit == 0) {
+            return DEFAULT_COMMAND_LIMIT;
+        }
+        if (limit < MIN_COMMAND_LIMIT || limit > MAX_COMMAND_LIMIT) {
+            throw new InvalidDeviceQueryException(
+                    "limit must be between %d and %d".formatted(MIN_COMMAND_LIMIT, MAX_COMMAND_LIMIT)
+            );
+        }
+        return limit;
+    }
+
+    private String buildCommandTopic(String deviceId) {
+        return "devices/%s/cmd".formatted(deviceId);
+    }
+
+    private String buildCommandPayload(Long commandId, ControlAction commandType, Instant requestedAt) {
+        return """
+                {"commandId":%d,"commandType":"%s","requestedAt":"%s"}
+                """.formatted(commandId, commandType.name(), requestedAt.toString()).trim();
     }
 
     private Range resolveRange(Instant from, Instant to) {

--- a/src/main/java/com/iot/IoT/service/exception/DeviceCommandPublishException.java
+++ b/src/main/java/com/iot/IoT/service/exception/DeviceCommandPublishException.java
@@ -1,0 +1,8 @@
+package com.iot.IoT.service.exception;
+
+public class DeviceCommandPublishException extends RuntimeException {
+
+    public DeviceCommandPublishException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/com/iot/IoT/controller/DeviceControllerTest.java
+++ b/src/test/java/com/iot/IoT/controller/DeviceControllerTest.java
@@ -1,6 +1,9 @@
 package com.iot.IoT.controller;
 
+import com.iot.IoT.control.ControlAction;
 import com.iot.IoT.dto.CreateDeviceRequest;
+import com.iot.IoT.dto.DeviceCommandPageResponse;
+import com.iot.IoT.dto.DeviceCommandResponse;
 import com.iot.IoT.dto.DeviceControlPolicyResponse;
 import com.iot.IoT.dto.DevicePageResponse;
 import com.iot.IoT.dto.DeviceResponse;
@@ -265,6 +268,87 @@ class DeviceControllerTest {
                                   "targetTemp": 64.5
                                 }
                                 """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    @DisplayName("POST /devices/{id}/commands should return sent command")
+    void sendCommand_success() throws Exception {
+        DeviceCommandResponse response = new DeviceCommandResponse(
+                10L,
+                1L,
+                "SV-001",
+                ControlAction.HEAT_ON,
+                com.iot.IoT.entity.DeviceCommandStatus.SENT,
+                "devices/SV-001/cmd",
+                "{\"commandId\":10,\"commandType\":\"HEAT_ON\"}",
+                Instant.parse("2026-03-02T00:00:00Z"),
+                Instant.parse("2026-03-02T00:00:01Z"),
+                null
+        );
+        when(deviceService.sendCommand(eq(1L), eq(ControlAction.HEAT_ON))).thenReturn(response);
+
+        mockMvc.perform(post("/devices/1/commands")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "commandType": "HEAT_ON"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.commandId").value(10))
+                .andExpect(jsonPath("$.status").value("SENT"))
+                .andExpect(jsonPath("$.commandType").value("HEAT_ON"));
+    }
+
+    @Test
+    @DisplayName("POST /devices/{id}/commands should validate request")
+    void sendCommand_invalidRequest() throws Exception {
+        mockMvc.perform(post("/devices/1/commands")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    @DisplayName("GET /devices/{id}/commands should return command history")
+    void getCommands_success() throws Exception {
+        DeviceCommandPageResponse response = new DeviceCommandPageResponse(
+                1L,
+                "SV-001",
+                20,
+                List.of(
+                        new DeviceCommandResponse(
+                                10L,
+                                1L,
+                                "SV-001",
+                                ControlAction.HEAT_ON,
+                                com.iot.IoT.entity.DeviceCommandStatus.SENT,
+                                "devices/SV-001/cmd",
+                                "{\"commandId\":10,\"commandType\":\"HEAT_ON\"}",
+                                Instant.parse("2026-03-02T00:00:00Z"),
+                                Instant.parse("2026-03-02T00:00:01Z"),
+                                null
+                        )
+                )
+        );
+        when(deviceService.getCommands(1L, 0)).thenReturn(response);
+
+        mockMvc.perform(get("/devices/1/commands"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items[0].commandType").value("HEAT_ON"))
+                .andExpect(jsonPath("$.items[0].status").value("SENT"));
+    }
+
+    @Test
+    @DisplayName("GET /devices/{id}/commands should validate limit")
+    void getCommands_invalidLimit() throws Exception {
+        when(deviceService.getCommands(1L, 101))
+                .thenThrow(new InvalidDeviceQueryException("limit must be between 1 and 100"));
+
+        mockMvc.perform(get("/devices/1/commands").param("limit", "101"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
     }

--- a/src/test/java/com/iot/IoT/service/DeviceServiceImplTest.java
+++ b/src/test/java/com/iot/IoT/service/DeviceServiceImplTest.java
@@ -1,6 +1,9 @@
 package com.iot.IoT.service;
 
+import com.iot.IoT.control.ControlAction;
 import com.iot.IoT.dto.CreateDeviceRequest;
+import com.iot.IoT.dto.DeviceCommandPageResponse;
+import com.iot.IoT.dto.DeviceCommandResponse;
 import com.iot.IoT.dto.DeviceControlPolicyResponse;
 import com.iot.IoT.dto.DevicePageResponse;
 import com.iot.IoT.dto.DeviceResponse;
@@ -8,8 +11,12 @@ import com.iot.IoT.dto.DeviceStatusResponse;
 import com.iot.IoT.dto.DeviceTemperaturePointResponse;
 import com.iot.IoT.dto.DeviceTemperatureSeriesResponse;
 import com.iot.IoT.entity.Device;
+import com.iot.IoT.entity.DeviceCommand;
+import com.iot.IoT.entity.DeviceCommandStatus;
 import com.iot.IoT.ingestion.dto.DeviceState;
 import com.iot.IoT.ingestion.port.TemperatureTimeSeriesQueryPort;
+import com.iot.IoT.mqtt.port.DeviceCommandPublisherPort;
+import com.iot.IoT.repository.DeviceCommandRepository;
 import com.iot.IoT.repository.DeviceRepository;
 import com.iot.IoT.service.exception.DeviceNotFoundException;
 import com.iot.IoT.service.exception.DuplicateDeviceException;
@@ -40,19 +47,25 @@ import static org.mockito.Mockito.when;
 class DeviceServiceImplTest {
 
     private DeviceRepository deviceRepository;
+    private DeviceCommandRepository deviceCommandRepository;
     private WatchdogStatePort watchdogStatePort;
     private TemperatureTimeSeriesQueryPort temperatureTimeSeriesQueryPort;
+    private DeviceCommandPublisherPort deviceCommandPublisherPort;
     private DeviceServiceImpl deviceService;
 
     @BeforeEach
     void setUp() {
         deviceRepository = Mockito.mock(DeviceRepository.class);
+        deviceCommandRepository = Mockito.mock(DeviceCommandRepository.class);
         watchdogStatePort = Mockito.mock(WatchdogStatePort.class);
         temperatureTimeSeriesQueryPort = Mockito.mock(TemperatureTimeSeriesQueryPort.class);
+        deviceCommandPublisherPort = Mockito.mock(DeviceCommandPublisherPort.class);
         deviceService = new DeviceServiceImpl(
                 deviceRepository,
+                deviceCommandRepository,
                 watchdogStatePort,
                 temperatureTimeSeriesQueryPort,
+                deviceCommandPublisherPort,
                 120
         );
     }
@@ -235,6 +248,94 @@ class DeviceServiceImplTest {
         verify(deviceRepository, times(1)).save(eq(device));
     }
 
+    @Test
+    @DisplayName("Should publish command and store SENT history")
+    void sendCommand_success() {
+        Device device = sampleDevice(1L, "SV-001", true);
+        when(deviceRepository.findById(1L)).thenReturn(Optional.of(device));
+        when(deviceCommandRepository.save(any(DeviceCommand.class)))
+                .thenAnswer(invocation -> {
+                    DeviceCommand command = invocation.getArgument(0);
+                    if (command.getId() == null) {
+                        setId(command, 10L);
+                    }
+                    if (command.getRequestedAt() == null) {
+                        command.setRequestedAt(Instant.parse("2026-03-02T00:00:00Z"));
+                    }
+                    return command;
+                });
+
+        DeviceCommandResponse response = deviceService.sendCommand(1L, ControlAction.HEAT_ON);
+
+        assertEquals(10L, response.commandId());
+        assertEquals(DeviceCommandStatus.SENT, response.status());
+        verify(deviceCommandPublisherPort, times(1))
+                .publish(eq("devices/SV-001/cmd"), any(String.class));
+    }
+
+    @Test
+    @DisplayName("Should store FAILED history when publish fails")
+    void sendCommand_publishFail() {
+        Device device = sampleDevice(1L, "SV-001", true);
+        when(deviceRepository.findById(1L)).thenReturn(Optional.of(device));
+        when(deviceCommandRepository.save(any(DeviceCommand.class)))
+                .thenAnswer(invocation -> {
+                    DeviceCommand command = invocation.getArgument(0);
+                    if (command.getId() == null) {
+                        setId(command, 11L);
+                    }
+                    if (command.getRequestedAt() == null) {
+                        command.setRequestedAt(Instant.parse("2026-03-02T00:00:00Z"));
+                    }
+                    return command;
+                });
+        Mockito.doThrow(new RuntimeException("publish failed"))
+                .when(deviceCommandPublisherPort)
+                .publish(eq("devices/SV-001/cmd"), any(String.class));
+
+        DeviceCommandResponse response = deviceService.sendCommand(1L, ControlAction.HEAT_OFF);
+
+        assertEquals(11L, response.commandId());
+        assertEquals(DeviceCommandStatus.FAILED, response.status());
+        assertEquals("publish failed", response.errorMessage());
+    }
+
+    @Test
+    @DisplayName("Should return command history with limit")
+    void getCommands_success() {
+        Device device = sampleDevice(1L, "SV-001", true);
+        DeviceCommand history = new DeviceCommand();
+        history.setDevicePk(1L);
+        history.setDeviceId("SV-001");
+        history.setCommandType(ControlAction.HOLD);
+        history.setStatus(DeviceCommandStatus.SENT);
+        history.setTopic("devices/SV-001/cmd");
+        history.setPayload("{\"commandId\":99}");
+        history.setRequestedAt(Instant.parse("2026-03-02T00:00:00Z"));
+        history.setSentAt(Instant.parse("2026-03-02T00:00:01Z"));
+        setId(history, 99L);
+
+        when(deviceRepository.findById(1L)).thenReturn(Optional.of(device));
+        when(deviceCommandRepository.findByDevicePkOrderByRequestedAtDesc(eq(1L), any(PageRequest.class)))
+                .thenReturn(List.of(history));
+
+        DeviceCommandPageResponse response = deviceService.getCommands(1L, 20);
+
+        assertEquals("SV-001", response.deviceId());
+        assertEquals(1, response.items().size());
+        assertEquals(ControlAction.HOLD, response.items().get(0).commandType());
+    }
+
+    @Test
+    @DisplayName("Should throw invalid query when command limit is out of range")
+    void getCommands_invalidLimit() {
+        Device device = sampleDevice(1L, "SV-001", true);
+        when(deviceRepository.findById(1L)).thenReturn(Optional.of(device));
+
+        assertThrows(InvalidDeviceQueryException.class,
+                () -> deviceService.getCommands(1L, 999));
+    }
+
     private Device sampleDevice(Long id, String deviceId, boolean enabled) {
         Device device = new Device();
         device.setDeviceId(deviceId);
@@ -258,6 +359,16 @@ class DeviceServiceImplTest {
             var updatedAtField = Device.class.getDeclaredField("updatedAt");
             updatedAtField.setAccessible(true);
             updatedAtField.set(device, now);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void setId(DeviceCommand command, Long id) {
+        try {
+            var idField = DeviceCommand.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(command, id);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## Summary
  - 변경 배경: 4단계 Downlink 기본 경로 구현 필요
  - 핵심 변경사항:
    - `POST /devices/{id}/commands` 추가 (publish + 이력 저장)
    - `GET /devices/{id}/commands` 추가 (이력 조회)
    - `DeviceCommand` 엔티티/리포지토리/DTO/서비스/컨트롤러/테스트 반영
    - MQTT 발행 어댑터 추가
    - API 문서 업데이트
  - Closes: #33

  ## Why
  - 이 변경이 필요한 이유:
    - 제품형 IoT 백엔드의 서버->디바이스 제어 최소 경로 제공

  ## Changes
  - [ ] Ingestion
  - [x] Control Loop
  - [ ] Watchdog/Fail-safe
  - [ ] Infra/Config
  - [x] Docs

  ## Test Evidence
  - 실행 커맨드: `./gradlew test`
  - 결과 요약: (사용자 로컬 결과 기입)
  - 로그/스크린샷: (첨부)

  ## Risk & Rollback
  - 예상 리스크: publish 실패 시 상태 전이/오류 메시지 누락 가능성
  - 롤백 방법: 본 PR revert

  ## Checklist
  - [x] 관련 이슈 링크를 연결했다.
  - [x] 예외/에러 처리 경로를 점검했다.
  - [x] 테스트를 추가/갱신했다.
  - [x] 성능 영향(고트래픽 관점)을 검토했다.