### PR TITLE
feat(downlink): add ack/idempotency/retry-timeout reliability flow

### DIFF
--- a/docs/device-api.md
+++ b/docs/device-api.md
@@ -140,11 +140,13 @@
 - Request body:
 ```json
 {
-  "commandType": "HEAT_ON"
+  "commandType": "HEAT_ON",
+  "idempotencyKey": "cmd-20260302-0001"
 }
 ```
 - Rules:
   - `commandType`: required (`HEAT_ON`, `HEAT_OFF`, `HOLD`)
+  - `idempotencyKey`: required, max 100
 - Response example:
 ```json
 {
@@ -161,7 +163,7 @@
 }
 ```
 - Responses:
-  - `200 OK` (`SENT` 또는 `FAILED`)
+  - `200 OK` (`SENT`, `FAILED`, 재요청 시 기존 command 반환)
   - `404 Not Found`
   - `400 Bad Request`
 
@@ -173,6 +175,24 @@
   - `200 OK`
   - `404 Not Found`
   - `400 Bad Request` (invalid `limit`)
+
+### 11) POST /devices/{id}/commands/{commandId}/ack
+- 설명: 다운링크 명령 ACK를 반영한다.
+- Responses:
+  - `200 OK` (`ACKED`)
+  - `404 Not Found` (`DEVICE_NOT_FOUND`, `COMMAND_NOT_FOUND`)
+
+## Downlink Reliability Notes (Phase 5)
+- 상태 모델:
+  - `PENDING`: 생성됨, 아직 발행 전
+  - `SENT`: 발행됨, ACK 대기
+  - `ACKED`: ACK 수신 완료
+  - `EXPIRED`: ACK timeout 초과
+  - `FAILED`: publish 실패 또는 retry 한도 초과
+- 기본 정책:
+  - `ack-timeout`: `30s` (기본값)
+  - `retry-interval`: `10s` (기본값)
+  - `max-retries`: `3` (기본값)
 
 ## Error Response Contract
 ```json
@@ -186,4 +206,5 @@
 ## Error Codes
 - `DEVICE_NOT_FOUND`
 - `DEVICE_DUPLICATE`
+- `COMMAND_NOT_FOUND`
 - `INVALID_REQUEST`

--- a/src/main/java/com/iot/IoT/controller/DeviceController.java
+++ b/src/main/java/com/iot/IoT/controller/DeviceController.java
@@ -101,7 +101,7 @@ public class DeviceController {
             @PathVariable Long id,
             @Valid @RequestBody SendDeviceCommandRequest request
     ) {
-        return deviceService.sendCommand(id, request.commandType());
+        return deviceService.sendCommand(id, request.commandType(), request.idempotencyKey());
     }
 
     @GetMapping("/{id}/commands")
@@ -110,5 +110,13 @@ public class DeviceController {
             @RequestParam(defaultValue = "0") int limit
     ) {
         return deviceService.getCommands(id, limit);
+    }
+
+    @PostMapping("/{id}/commands/{commandId}/ack")
+    public DeviceCommandResponse acknowledgeCommand(
+            @PathVariable Long id,
+            @PathVariable Long commandId
+    ) {
+        return deviceService.acknowledgeCommand(id, commandId);
     }
 }

--- a/src/main/java/com/iot/IoT/controller/GlobalApiExceptionHandler.java
+++ b/src/main/java/com/iot/IoT/controller/GlobalApiExceptionHandler.java
@@ -2,6 +2,7 @@ package com.iot.IoT.controller;
 
 import com.iot.IoT.dto.ApiErrorResponse;
 import com.iot.IoT.service.exception.DeviceNotFoundException;
+import com.iot.IoT.service.exception.DeviceCommandNotFoundException;
 import com.iot.IoT.service.exception.DuplicateDeviceException;
 import com.iot.IoT.service.exception.InvalidDeviceQueryException;
 import jakarta.validation.ConstraintViolationException;
@@ -21,6 +22,11 @@ public class GlobalApiExceptionHandler {
     @ExceptionHandler(DeviceNotFoundException.class)
     public ResponseEntity<ApiErrorResponse> handleDeviceNotFound(DeviceNotFoundException ex) {
         return error(HttpStatus.NOT_FOUND, "DEVICE_NOT_FOUND", ex.getMessage());
+    }
+
+    @ExceptionHandler(DeviceCommandNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleDeviceCommandNotFound(DeviceCommandNotFoundException ex) {
+        return error(HttpStatus.NOT_FOUND, "COMMAND_NOT_FOUND", ex.getMessage());
     }
 
     @ExceptionHandler(DuplicateDeviceException.class)

--- a/src/main/java/com/iot/IoT/dto/SendDeviceCommandRequest.java
+++ b/src/main/java/com/iot/IoT/dto/SendDeviceCommandRequest.java
@@ -1,9 +1,12 @@
 package com.iot.IoT.dto;
 
 import com.iot.IoT.control.ControlAction;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record SendDeviceCommandRequest(
-        @NotNull ControlAction commandType
+        @NotNull ControlAction commandType,
+        @NotBlank @Size(max = 100) String idempotencyKey
 ) {
 }

--- a/src/main/java/com/iot/IoT/entity/DeviceCommand.java
+++ b/src/main/java/com/iot/IoT/entity/DeviceCommand.java
@@ -41,6 +41,24 @@ public class DeviceCommand {
     @Column(name = "payload", nullable = false, length = 1000)
     private String payload;
 
+    @Column(name = "idempotency_key", nullable = false, length = 100)
+    private String idempotencyKey;
+
+    @Column(name = "retry_count", nullable = false)
+    private int retryCount;
+
+    @Column(name = "max_retries", nullable = false)
+    private int maxRetries;
+
+    @Column(name = "next_retry_at")
+    private Instant nextRetryAt;
+
+    @Column(name = "expire_at")
+    private Instant expireAt;
+
+    @Column(name = "acked_at")
+    private Instant ackedAt;
+
     @Column(name = "requested_at", nullable = false, updatable = false)
     private Instant requestedAt;
 
@@ -100,6 +118,54 @@ public class DeviceCommand {
 
     public void setPayload(String payload) {
         this.payload = payload;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public void setIdempotencyKey(String idempotencyKey) {
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    public int getRetryCount() {
+        return retryCount;
+    }
+
+    public void setRetryCount(int retryCount) {
+        this.retryCount = retryCount;
+    }
+
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    public void setMaxRetries(int maxRetries) {
+        this.maxRetries = maxRetries;
+    }
+
+    public Instant getNextRetryAt() {
+        return nextRetryAt;
+    }
+
+    public void setNextRetryAt(Instant nextRetryAt) {
+        this.nextRetryAt = nextRetryAt;
+    }
+
+    public Instant getExpireAt() {
+        return expireAt;
+    }
+
+    public void setExpireAt(Instant expireAt) {
+        this.expireAt = expireAt;
+    }
+
+    public Instant getAckedAt() {
+        return ackedAt;
+    }
+
+    public void setAckedAt(Instant ackedAt) {
+        this.ackedAt = ackedAt;
     }
 
     public Instant getRequestedAt() {

--- a/src/main/java/com/iot/IoT/entity/DeviceCommandStatus.java
+++ b/src/main/java/com/iot/IoT/entity/DeviceCommandStatus.java
@@ -3,5 +3,7 @@ package com.iot.IoT.entity;
 public enum DeviceCommandStatus {
     PENDING,
     SENT,
+    ACKED,
+    EXPIRED,
     FAILED
 }

--- a/src/main/java/com/iot/IoT/repository/DeviceCommandRepository.java
+++ b/src/main/java/com/iot/IoT/repository/DeviceCommandRepository.java
@@ -1,12 +1,21 @@
 package com.iot.IoT.repository;
 
 import com.iot.IoT.entity.DeviceCommand;
+import com.iot.IoT.entity.DeviceCommandStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface DeviceCommandRepository extends JpaRepository<DeviceCommand, Long> {
 
     List<DeviceCommand> findByDevicePkOrderByRequestedAtDesc(Long devicePk, Pageable pageable);
+
+    Optional<DeviceCommand> findByDevicePkAndIdempotencyKey(Long devicePk, String idempotencyKey);
+
+    Optional<DeviceCommand> findByIdAndDevicePk(Long id, Long devicePk);
+
+    List<DeviceCommand> findByStatusIn(Collection<DeviceCommandStatus> statuses);
 }

--- a/src/main/java/com/iot/IoT/service/DeviceCommandReliabilityScheduler.java
+++ b/src/main/java/com/iot/IoT/service/DeviceCommandReliabilityScheduler.java
@@ -1,0 +1,19 @@
+package com.iot.IoT.service;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeviceCommandReliabilityScheduler {
+
+    private final DeviceService deviceService;
+
+    public DeviceCommandReliabilityScheduler(DeviceService deviceService) {
+        this.deviceService = deviceService;
+    }
+
+    @Scheduled(fixedDelayString = "${downlink.reliability.scan-interval-ms:5000}")
+    public void scanAndProcess() {
+        deviceService.processCommandReliability();
+    }
+}

--- a/src/main/java/com/iot/IoT/service/DeviceService.java
+++ b/src/main/java/com/iot/IoT/service/DeviceService.java
@@ -31,7 +31,11 @@ public interface DeviceService {
 
     DeviceControlPolicyResponse updateControlPolicy(Long id, BigDecimal targetTemp, BigDecimal hysteresis);
 
-    DeviceCommandResponse sendCommand(Long id, ControlAction commandType);
+    DeviceCommandResponse sendCommand(Long id, ControlAction commandType, String idempotencyKey);
 
     DeviceCommandPageResponse getCommands(Long id, int limit);
+
+    DeviceCommandResponse acknowledgeCommand(Long id, Long commandId);
+
+    void processCommandReliability();
 }

--- a/src/main/java/com/iot/IoT/service/DeviceServiceImpl.java
+++ b/src/main/java/com/iot/IoT/service/DeviceServiceImpl.java
@@ -17,6 +17,7 @@ import com.iot.IoT.ingestion.port.TemperatureTimeSeriesQueryPort;
 import com.iot.IoT.mqtt.port.DeviceCommandPublisherPort;
 import com.iot.IoT.repository.DeviceCommandRepository;
 import com.iot.IoT.repository.DeviceRepository;
+import com.iot.IoT.service.exception.DeviceCommandNotFoundException;
 import com.iot.IoT.service.exception.DeviceNotFoundException;
 import com.iot.IoT.service.exception.DuplicateDeviceException;
 import com.iot.IoT.service.exception.InvalidDeviceQueryException;
@@ -31,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -46,6 +48,8 @@ public class DeviceServiceImpl implements DeviceService {
     private static final int MIN_COMMAND_LIMIT = 1;
     private static final int MAX_COMMAND_LIMIT = 100;
     private static final Duration DEFAULT_RANGE = Duration.ofHours(1);
+    private static final EnumSet<DeviceCommandStatus> RELIABILITY_TARGET_STATUSES =
+            EnumSet.of(DeviceCommandStatus.SENT, DeviceCommandStatus.PENDING);
 
     private final DeviceRepository deviceRepository;
     private final DeviceCommandRepository deviceCommandRepository;
@@ -53,6 +57,9 @@ public class DeviceServiceImpl implements DeviceService {
     private final TemperatureTimeSeriesQueryPort temperatureTimeSeriesQueryPort;
     private final DeviceCommandPublisherPort deviceCommandPublisherPort;
     private final Duration heartbeatTtl;
+    private final Duration commandRetryInterval;
+    private final Duration commandAckTimeout;
+    private final int commandMaxRetries;
 
     public DeviceServiceImpl(
             DeviceRepository deviceRepository,
@@ -60,7 +67,10 @@ public class DeviceServiceImpl implements DeviceService {
             WatchdogStatePort watchdogStatePort,
             TemperatureTimeSeriesQueryPort temperatureTimeSeriesQueryPort,
             DeviceCommandPublisherPort deviceCommandPublisherPort,
-            @Value("${ingestion.heartbeat-ttl-seconds:120}") long heartbeatTtlSeconds
+            @Value("${ingestion.heartbeat-ttl-seconds:120}") long heartbeatTtlSeconds,
+            @Value("${downlink.retry-interval-seconds:10}") long commandRetryIntervalSeconds,
+            @Value("${downlink.ack-timeout-seconds:30}") long commandAckTimeoutSeconds,
+            @Value("${downlink.max-retries:3}") int commandMaxRetries
     ) {
         this.deviceRepository = deviceRepository;
         this.deviceCommandRepository = deviceCommandRepository;
@@ -68,6 +78,9 @@ public class DeviceServiceImpl implements DeviceService {
         this.temperatureTimeSeriesQueryPort = temperatureTimeSeriesQueryPort;
         this.deviceCommandPublisherPort = deviceCommandPublisherPort;
         this.heartbeatTtl = Duration.ofSeconds(heartbeatTtlSeconds);
+        this.commandRetryInterval = Duration.ofSeconds(commandRetryIntervalSeconds);
+        this.commandAckTimeout = Duration.ofSeconds(commandAckTimeoutSeconds);
+        this.commandMaxRetries = Math.max(commandMaxRetries, 0);
     }
 
     @Override
@@ -185,15 +198,26 @@ public class DeviceServiceImpl implements DeviceService {
 
     @Override
     @Transactional
-    public DeviceCommandResponse sendCommand(Long id, ControlAction commandType) {
+    public DeviceCommandResponse sendCommand(Long id, ControlAction commandType, String idempotencyKey) {
         Device device = findEntity(id);
+        Optional<DeviceCommand> existing = deviceCommandRepository.findByDevicePkAndIdempotencyKey(
+                device.getId(),
+                idempotencyKey
+        );
+        if (existing.isPresent()) {
+            return toCommandResponse(existing.get());
+        }
+
         String topic = buildCommandTopic(device.getDeviceId());
 
         DeviceCommand command = new DeviceCommand();
         command.setDevicePk(device.getId());
         command.setDeviceId(device.getDeviceId());
+        command.setIdempotencyKey(idempotencyKey);
         command.setCommandType(commandType);
         command.setStatus(DeviceCommandStatus.PENDING);
+        command.setRetryCount(0);
+        command.setMaxRetries(commandMaxRetries);
         command.setTopic(topic);
         command.setPayload("");
 
@@ -203,17 +227,21 @@ public class DeviceServiceImpl implements DeviceService {
         }
         Instant requestedAt = created.getRequestedAt() == null ? Instant.now() : created.getRequestedAt();
         created.setRequestedAt(requestedAt);
+        created.setExpireAt(requestedAt.plus(commandAckTimeout));
         String payload = buildCommandPayload(created.getId(), commandType, requestedAt);
         created.setPayload(payload);
 
         try {
             deviceCommandPublisherPort.publish(topic, payload);
+            Instant sentAt = Instant.now();
             created.setStatus(DeviceCommandStatus.SENT);
-            created.setSentAt(Instant.now());
+            created.setSentAt(sentAt);
+            created.setNextRetryAt(sentAt.plus(commandRetryInterval));
             created.setErrorMessage(null);
         } catch (RuntimeException ex) {
             created.setStatus(DeviceCommandStatus.FAILED);
             created.setSentAt(null);
+            created.setNextRetryAt(null);
             created.setErrorMessage(ex.getMessage());
         }
 
@@ -233,6 +261,54 @@ public class DeviceServiceImpl implements DeviceService {
                 .map(this::toCommandResponse)
                 .toList();
         return new DeviceCommandPageResponse(device.getId(), device.getDeviceId(), normalizedLimit, items);
+    }
+
+    @Override
+    @Transactional
+    public DeviceCommandResponse acknowledgeCommand(Long id, Long commandId) {
+        Device device = findEntity(id);
+        DeviceCommand command = deviceCommandRepository.findByIdAndDevicePk(commandId, device.getId())
+                .orElseThrow(() -> new DeviceCommandNotFoundException(device.getId(), commandId));
+
+        if (command.getStatus() != DeviceCommandStatus.ACKED) {
+            command.setStatus(DeviceCommandStatus.ACKED);
+            command.setAckedAt(Instant.now());
+            command.setNextRetryAt(null);
+            command.setErrorMessage(null);
+            command = deviceCommandRepository.save(command);
+        }
+        return toCommandResponse(command);
+    }
+
+    @Override
+    @Transactional
+    public void processCommandReliability() {
+        Instant now = Instant.now();
+        List<DeviceCommand> targets = deviceCommandRepository.findByStatusIn(RELIABILITY_TARGET_STATUSES);
+        for (DeviceCommand command : targets) {
+            if (command.getStatus() == DeviceCommandStatus.ACKED
+                    || command.getStatus() == DeviceCommandStatus.EXPIRED
+                    || command.getStatus() == DeviceCommandStatus.FAILED) {
+                continue;
+            }
+            if (command.getExpireAt() != null && now.isAfter(command.getExpireAt())) {
+                command.setStatus(DeviceCommandStatus.EXPIRED);
+                command.setNextRetryAt(null);
+                command.setErrorMessage("ack timeout expired");
+                deviceCommandRepository.save(command);
+                continue;
+            }
+            if (command.getStatus() == DeviceCommandStatus.PENDING) {
+                retryPublish(command, now);
+                continue;
+            }
+            if (command.getStatus() == DeviceCommandStatus.SENT
+                    && command.getNextRetryAt() != null
+                    && !now.isBefore(command.getNextRetryAt())
+                    && command.getRetryCount() < command.getMaxRetries()) {
+                retryPublish(command, now);
+            }
+        }
     }
 
     private Device findEntity(Long id) {
@@ -274,6 +350,29 @@ public class DeviceServiceImpl implements DeviceService {
                 command.getSentAt(),
                 command.getErrorMessage()
         );
+    }
+
+    private void retryPublish(DeviceCommand command, Instant now) {
+        try {
+            deviceCommandPublisherPort.publish(command.getTopic(), command.getPayload());
+            command.setStatus(DeviceCommandStatus.SENT);
+            command.setSentAt(now);
+            command.setRetryCount(command.getRetryCount() + 1);
+            command.setNextRetryAt(now.plus(commandRetryInterval));
+            command.setErrorMessage(null);
+        } catch (RuntimeException ex) {
+            int nextRetry = command.getRetryCount() + 1;
+            command.setRetryCount(nextRetry);
+            if (nextRetry >= command.getMaxRetries()) {
+                command.setStatus(DeviceCommandStatus.FAILED);
+                command.setNextRetryAt(null);
+            } else {
+                command.setStatus(DeviceCommandStatus.SENT);
+                command.setNextRetryAt(now.plus(commandRetryInterval));
+            }
+            command.setErrorMessage(ex.getMessage());
+        }
+        deviceCommandRepository.save(command);
     }
 
     private static String normalize(String value) {

--- a/src/main/java/com/iot/IoT/service/exception/DeviceCommandNotFoundException.java
+++ b/src/main/java/com/iot/IoT/service/exception/DeviceCommandNotFoundException.java
@@ -1,0 +1,8 @@
+package com.iot.IoT.service.exception;
+
+public class DeviceCommandNotFoundException extends RuntimeException {
+
+    public DeviceCommandNotFoundException(Long devicePk, Long commandId) {
+        super("Device command not found. devicePk=" + devicePk + ", commandId=" + commandId);
+    }
+}

--- a/src/test/java/com/iot/IoT/controller/DeviceControllerTest.java
+++ b/src/test/java/com/iot/IoT/controller/DeviceControllerTest.java
@@ -287,13 +287,14 @@ class DeviceControllerTest {
                 Instant.parse("2026-03-02T00:00:01Z"),
                 null
         );
-        when(deviceService.sendCommand(eq(1L), eq(ControlAction.HEAT_ON))).thenReturn(response);
+        when(deviceService.sendCommand(eq(1L), eq(ControlAction.HEAT_ON), eq("idem-1"))).thenReturn(response);
 
         mockMvc.perform(post("/devices/1/commands")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "commandType": "HEAT_ON"
+                                  "commandType": "HEAT_ON",
+                                  "idempotencyKey": "idem-1"
                                 }
                                 """))
                 .andExpect(status().isOk())
@@ -351,6 +352,28 @@ class DeviceControllerTest {
         mockMvc.perform(get("/devices/1/commands").param("limit", "101"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    @DisplayName("POST /devices/{id}/commands/{commandId}/ack should return ACKED")
+    void acknowledgeCommand_success() throws Exception {
+        DeviceCommandResponse response = new DeviceCommandResponse(
+                10L,
+                1L,
+                "SV-001",
+                ControlAction.HEAT_ON,
+                com.iot.IoT.entity.DeviceCommandStatus.ACKED,
+                "devices/SV-001/cmd",
+                "{\"commandId\":10,\"commandType\":\"HEAT_ON\"}",
+                Instant.parse("2026-03-02T00:00:00Z"),
+                Instant.parse("2026-03-02T00:00:01Z"),
+                null
+        );
+        when(deviceService.acknowledgeCommand(1L, 10L)).thenReturn(response);
+
+        mockMvc.perform(post("/devices/1/commands/10/ack"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ACKED"));
     }
 
     private DeviceResponse sampleResponse(Long id, String deviceId, boolean enabled) {

--- a/src/test/java/com/iot/IoT/service/DeviceServiceImplTest.java
+++ b/src/test/java/com/iot/IoT/service/DeviceServiceImplTest.java
@@ -18,6 +18,7 @@ import com.iot.IoT.ingestion.port.TemperatureTimeSeriesQueryPort;
 import com.iot.IoT.mqtt.port.DeviceCommandPublisherPort;
 import com.iot.IoT.repository.DeviceCommandRepository;
 import com.iot.IoT.repository.DeviceRepository;
+import com.iot.IoT.service.exception.DeviceCommandNotFoundException;
 import com.iot.IoT.service.exception.DeviceNotFoundException;
 import com.iot.IoT.service.exception.DuplicateDeviceException;
 import com.iot.IoT.service.exception.InvalidDeviceQueryException;
@@ -66,7 +67,10 @@ class DeviceServiceImplTest {
                 watchdogStatePort,
                 temperatureTimeSeriesQueryPort,
                 deviceCommandPublisherPort,
-                120
+                120,
+                10,
+                30,
+                3
         );
     }
 
@@ -265,7 +269,9 @@ class DeviceServiceImplTest {
                     return command;
                 });
 
-        DeviceCommandResponse response = deviceService.sendCommand(1L, ControlAction.HEAT_ON);
+        when(deviceCommandRepository.findByDevicePkAndIdempotencyKey(1L, "idem-1")).thenReturn(Optional.empty());
+
+        DeviceCommandResponse response = deviceService.sendCommand(1L, ControlAction.HEAT_ON, "idem-1");
 
         assertEquals(10L, response.commandId());
         assertEquals(DeviceCommandStatus.SENT, response.status());
@@ -293,7 +299,9 @@ class DeviceServiceImplTest {
                 .when(deviceCommandPublisherPort)
                 .publish(eq("devices/SV-001/cmd"), any(String.class));
 
-        DeviceCommandResponse response = deviceService.sendCommand(1L, ControlAction.HEAT_OFF);
+        when(deviceCommandRepository.findByDevicePkAndIdempotencyKey(1L, "idem-2")).thenReturn(Optional.empty());
+
+        DeviceCommandResponse response = deviceService.sendCommand(1L, ControlAction.HEAT_OFF, "idem-2");
 
         assertEquals(11L, response.commandId());
         assertEquals(DeviceCommandStatus.FAILED, response.status());
@@ -324,6 +332,110 @@ class DeviceServiceImplTest {
         assertEquals("SV-001", response.deviceId());
         assertEquals(1, response.items().size());
         assertEquals(ControlAction.HOLD, response.items().get(0).commandType());
+    }
+
+    @Test
+    @DisplayName("Should return existing command when idempotency key already exists")
+    void sendCommand_idempotencyHit() {
+        Device device = sampleDevice(1L, "SV-001", true);
+        DeviceCommand existing = new DeviceCommand();
+        existing.setDevicePk(1L);
+        existing.setDeviceId("SV-001");
+        existing.setCommandType(ControlAction.HEAT_ON);
+        existing.setStatus(DeviceCommandStatus.SENT);
+        existing.setTopic("devices/SV-001/cmd");
+        existing.setPayload("{\"commandId\":77}");
+        existing.setIdempotencyKey("idem-hit");
+        existing.setRequestedAt(Instant.parse("2026-03-02T00:00:00Z"));
+        setId(existing, 77L);
+
+        when(deviceRepository.findById(1L)).thenReturn(Optional.of(device));
+        when(deviceCommandRepository.findByDevicePkAndIdempotencyKey(1L, "idem-hit"))
+                .thenReturn(Optional.of(existing));
+
+        DeviceCommandResponse response = deviceService.sendCommand(1L, ControlAction.HEAT_ON, "idem-hit");
+
+        assertEquals(77L, response.commandId());
+        verify(deviceCommandPublisherPort, never()).publish(any(String.class), any(String.class));
+    }
+
+    @Test
+    @DisplayName("Should acknowledge command")
+    void acknowledgeCommand_success() {
+        Device device = sampleDevice(1L, "SV-001", true);
+        DeviceCommand command = new DeviceCommand();
+        command.setDevicePk(1L);
+        command.setDeviceId("SV-001");
+        command.setCommandType(ControlAction.HEAT_ON);
+        command.setStatus(DeviceCommandStatus.SENT);
+        command.setTopic("devices/SV-001/cmd");
+        command.setPayload("{\"commandId\":12}");
+        command.setIdempotencyKey("ack-1");
+        command.setRequestedAt(Instant.parse("2026-03-02T00:00:00Z"));
+        setId(command, 12L);
+
+        when(deviceRepository.findById(1L)).thenReturn(Optional.of(device));
+        when(deviceCommandRepository.findByIdAndDevicePk(12L, 1L)).thenReturn(Optional.of(command));
+        when(deviceCommandRepository.save(any(DeviceCommand.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        DeviceCommandResponse response = deviceService.acknowledgeCommand(1L, 12L);
+
+        assertEquals(DeviceCommandStatus.ACKED, response.status());
+    }
+
+    @Test
+    @DisplayName("Should throw when acknowledging missing command")
+    void acknowledgeCommand_notFound() {
+        Device device = sampleDevice(1L, "SV-001", true);
+        when(deviceRepository.findById(1L)).thenReturn(Optional.of(device));
+        when(deviceCommandRepository.findByIdAndDevicePk(12L, 1L)).thenReturn(Optional.empty());
+
+        assertThrows(DeviceCommandNotFoundException.class, () -> deviceService.acknowledgeCommand(1L, 12L));
+    }
+
+    @Test
+    @DisplayName("Should expire command when ack timeout is reached")
+    void processCommandReliability_expire() {
+        DeviceCommand command = new DeviceCommand();
+        command.setStatus(DeviceCommandStatus.SENT);
+        command.setTopic("devices/SV-001/cmd");
+        command.setPayload("{\"commandId\":1}");
+        command.setRetryCount(0);
+        command.setMaxRetries(3);
+        command.setExpireAt(Instant.now().minusSeconds(1));
+        command.setRequestedAt(Instant.now().minusSeconds(10));
+        command.setIdempotencyKey("exp-1");
+
+        when(deviceCommandRepository.findByStatusIn(any())).thenReturn(List.of(command));
+        when(deviceCommandRepository.save(any(DeviceCommand.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        deviceService.processCommandReliability();
+
+        assertEquals(DeviceCommandStatus.EXPIRED, command.getStatus());
+    }
+
+    @Test
+    @DisplayName("Should retry publish when nextRetryAt is due")
+    void processCommandReliability_retry() {
+        DeviceCommand command = new DeviceCommand();
+        command.setStatus(DeviceCommandStatus.SENT);
+        command.setTopic("devices/SV-001/cmd");
+        command.setPayload("{\"commandId\":2}");
+        command.setRetryCount(0);
+        command.setMaxRetries(3);
+        command.setRequestedAt(Instant.now().minusSeconds(10));
+        command.setExpireAt(Instant.now().plusSeconds(20));
+        command.setNextRetryAt(Instant.now().minusSeconds(1));
+        command.setIdempotencyKey("retry-1");
+
+        when(deviceCommandRepository.findByStatusIn(any())).thenReturn(List.of(command));
+        when(deviceCommandRepository.save(any(DeviceCommand.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        deviceService.processCommandReliability();
+
+        verify(deviceCommandPublisherPort, times(1)).publish(eq("devices/SV-001/cmd"), eq("{\"commandId\":2}"));
+        assertEquals(1, command.getRetryCount());
+        assertEquals(DeviceCommandStatus.SENT, command.getStatus());
     }
 
     @Test


### PR DESCRIPTION
## Summary
  - 변경 배경: 5단계 Downlink 신뢰성(ACK/timeout/retry/idempotency) 구현
  - 핵심 변경사항:
    - command 요청에 `idempotencyKey` 추가
    - `POST /devices/{id}/commands/{commandId}/ack` 추가
    - 상태 확장: `ACKED`, `EXPIRED`
    - retry/timeout 스케줄러 추가
    - `COMMAND_NOT_FOUND` 에러 코드 추가
    - 테스트/문서 업데이트
  - Closes: #35

  ## Why
  - 이 변경이 필요한 이유:
    - 명령 발행 이후 ACK/재시도/만료를 포함한 신뢰성 경로 확보

  ## Changes
  - [ ] Ingestion
  - [x] Control Loop
  - [ ] Watchdog/Fail-safe
  - [ ] Infra/Config
  - [x] Docs

  ## Test Evidence
  - 실행 커맨드: `./gradlew test`
  - 결과 요약: (로컬 결과 기입)
  - 로그/스크린샷: (첨부)

  ## Risk & Rollback
  - 예상 리스크: retry/timeout 파라미터 튜닝 미흡 시 명령 지연 가능
  - 롤백 방법: 본 PR revert

  ## Checklist
  - [x] 관련 이슈 링크를 연결했다.
  - [x] 예외/에러 처리 경로를 점검했다.
  - [x] 테스트를 추가/갱신했다.
  - [x] 성능 영향(고트래픽 관점)을 검토했다.