### PR TITLE
feat(observability): add actuator prometheus and baseline metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	// 1. Web Framework
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation' // 데이터 유효성 검증
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 
 	// 2. IoT Messaging (MQTT) - 핵심
 	// 단순 Paho Client가 아닌 Spring Integration을 사용하여 메시지 채널을 관리한다.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,44 @@
+# Observability Baseline (Phase 6)
+
+## Purpose
+- 운영 지표를 표준 endpoint로 노출한다.
+- Prometheus/Grafana 연동의 1차 기반을 제공한다.
+
+## Enabled Endpoints
+- `GET /actuator/health`
+- `GET /actuator/info`
+- `GET /actuator/metrics`
+- `GET /actuator/prometheus`
+
+## How To Verify
+1. 애플리케이션 실행
+2. health 확인
+```bash
+curl -s http://localhost:8080/actuator/health
+```
+3. prometheus 메트릭 확인
+```bash
+curl -s http://localhost:8080/actuator/prometheus | rg "^iot\\."
+```
+
+## Metric Names
+- Ingestion:
+  - `iot_ingestion_mqtt_received_total`
+  - `iot_ingestion_parse_success_total`
+  - `iot_ingestion_parse_failure_total`
+  - `iot_ingestion_influx_success_total`
+  - `iot_ingestion_influx_failure_total`
+  - `iot_ingestion_influx_bypass_total`
+  - `iot_ingestion_redis_success_total`
+  - `iot_ingestion_redis_failure_total`
+- Downlink:
+  - `iot_downlink_command_sent_total`
+  - `iot_downlink_command_failed_total`
+  - `iot_downlink_command_acked_total`
+  - `iot_downlink_command_expired_total`
+  - `iot_downlink_command_retried_total`
+  - `iot_downlink_command_idempotency_hit_total`
+
+## Common Tags
+- `application`: `${spring.application.name}`
+- `env`: `${APP_ENV:local}`

--- a/src/main/java/com/iot/IoT/ingestion/metrics/IngestionMetricsCollector.java
+++ b/src/main/java/com/iot/IoT/ingestion/metrics/IngestionMetricsCollector.java
@@ -1,5 +1,7 @@
 package com.iot.IoT.ingestion.metrics;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -33,36 +35,64 @@ public class IngestionMetricsCollector {
     private final AtomicLong lastRedisSuccess = new AtomicLong(0);
     private final AtomicLong lastRedisFailure = new AtomicLong(0);
 
+    private final Counter mqttReceivedCounter;
+    private final Counter parseSuccessCounter;
+    private final Counter parseFailureCounter;
+    private final Counter influxSuccessCounter;
+    private final Counter influxFailureCounter;
+    private final Counter influxBypassCounter;
+    private final Counter redisSuccessCounter;
+    private final Counter redisFailureCounter;
+
+    public IngestionMetricsCollector(MeterRegistry meterRegistry) {
+        this.mqttReceivedCounter = meterRegistry.counter("iot.ingestion.mqtt.received.total");
+        this.parseSuccessCounter = meterRegistry.counter("iot.ingestion.parse.success.total");
+        this.parseFailureCounter = meterRegistry.counter("iot.ingestion.parse.failure.total");
+        this.influxSuccessCounter = meterRegistry.counter("iot.ingestion.influx.success.total");
+        this.influxFailureCounter = meterRegistry.counter("iot.ingestion.influx.failure.total");
+        this.influxBypassCounter = meterRegistry.counter("iot.ingestion.influx.bypass.total");
+        this.redisSuccessCounter = meterRegistry.counter("iot.ingestion.redis.success.total");
+        this.redisFailureCounter = meterRegistry.counter("iot.ingestion.redis.failure.total");
+    }
+
     public void recordMqttReceived() {
         mqttReceivedTotal.increment();
+        mqttReceivedCounter.increment();
     }
 
     public void recordParseSuccess() {
         parseSuccessTotal.increment();
+        parseSuccessCounter.increment();
     }
 
     public void recordParseFailure() {
         parseFailureTotal.increment();
+        parseFailureCounter.increment();
     }
 
     public void recordInfluxSuccess() {
         influxSuccessTotal.increment();
+        influxSuccessCounter.increment();
     }
 
     public void recordInfluxFailure() {
         influxFailureTotal.increment();
+        influxFailureCounter.increment();
     }
 
     public void recordInfluxBypass() {
         influxBypassTotal.increment();
+        influxBypassCounter.increment();
     }
 
     public void recordRedisSuccess() {
         redisSuccessTotal.increment();
+        redisSuccessCounter.increment();
     }
 
     public void recordRedisFailure() {
         redisFailureTotal.increment();
+        redisFailureCounter.increment();
     }
 
     @Scheduled(fixedDelayString = "${ingestion.metrics-log-interval-ms:1000}")

--- a/src/main/java/com/iot/IoT/service/DeviceServiceImpl.java
+++ b/src/main/java/com/iot/IoT/service/DeviceServiceImpl.java
@@ -21,6 +21,7 @@ import com.iot.IoT.service.exception.DeviceCommandNotFoundException;
 import com.iot.IoT.service.exception.DeviceNotFoundException;
 import com.iot.IoT.service.exception.DuplicateDeviceException;
 import com.iot.IoT.service.exception.InvalidDeviceQueryException;
+import com.iot.IoT.service.metrics.DownlinkMetricsRecorder;
 import com.iot.IoT.watchdog.port.WatchdogStatePort;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -56,6 +57,7 @@ public class DeviceServiceImpl implements DeviceService {
     private final WatchdogStatePort watchdogStatePort;
     private final TemperatureTimeSeriesQueryPort temperatureTimeSeriesQueryPort;
     private final DeviceCommandPublisherPort deviceCommandPublisherPort;
+    private final DownlinkMetricsRecorder downlinkMetricsRecorder;
     private final Duration heartbeatTtl;
     private final Duration commandRetryInterval;
     private final Duration commandAckTimeout;
@@ -67,6 +69,7 @@ public class DeviceServiceImpl implements DeviceService {
             WatchdogStatePort watchdogStatePort,
             TemperatureTimeSeriesQueryPort temperatureTimeSeriesQueryPort,
             DeviceCommandPublisherPort deviceCommandPublisherPort,
+            DownlinkMetricsRecorder downlinkMetricsRecorder,
             @Value("${ingestion.heartbeat-ttl-seconds:120}") long heartbeatTtlSeconds,
             @Value("${downlink.retry-interval-seconds:10}") long commandRetryIntervalSeconds,
             @Value("${downlink.ack-timeout-seconds:30}") long commandAckTimeoutSeconds,
@@ -77,6 +80,7 @@ public class DeviceServiceImpl implements DeviceService {
         this.watchdogStatePort = watchdogStatePort;
         this.temperatureTimeSeriesQueryPort = temperatureTimeSeriesQueryPort;
         this.deviceCommandPublisherPort = deviceCommandPublisherPort;
+        this.downlinkMetricsRecorder = downlinkMetricsRecorder;
         this.heartbeatTtl = Duration.ofSeconds(heartbeatTtlSeconds);
         this.commandRetryInterval = Duration.ofSeconds(commandRetryIntervalSeconds);
         this.commandAckTimeout = Duration.ofSeconds(commandAckTimeoutSeconds);
@@ -205,6 +209,7 @@ public class DeviceServiceImpl implements DeviceService {
                 idempotencyKey
         );
         if (existing.isPresent()) {
+            downlinkMetricsRecorder.recordIdempotencyHit();
             return toCommandResponse(existing.get());
         }
 
@@ -238,11 +243,13 @@ public class DeviceServiceImpl implements DeviceService {
             created.setSentAt(sentAt);
             created.setNextRetryAt(sentAt.plus(commandRetryInterval));
             created.setErrorMessage(null);
+            downlinkMetricsRecorder.recordSent();
         } catch (RuntimeException ex) {
             created.setStatus(DeviceCommandStatus.FAILED);
             created.setSentAt(null);
             created.setNextRetryAt(null);
             created.setErrorMessage(ex.getMessage());
+            downlinkMetricsRecorder.recordFailed();
         }
 
         DeviceCommand saved = deviceCommandRepository.save(created);
@@ -276,6 +283,7 @@ public class DeviceServiceImpl implements DeviceService {
             command.setNextRetryAt(null);
             command.setErrorMessage(null);
             command = deviceCommandRepository.save(command);
+            downlinkMetricsRecorder.recordAcked();
         }
         return toCommandResponse(command);
     }
@@ -296,6 +304,7 @@ public class DeviceServiceImpl implements DeviceService {
                 command.setNextRetryAt(null);
                 command.setErrorMessage("ack timeout expired");
                 deviceCommandRepository.save(command);
+                downlinkMetricsRecorder.recordExpired();
                 continue;
             }
             if (command.getStatus() == DeviceCommandStatus.PENDING) {
@@ -360,15 +369,19 @@ public class DeviceServiceImpl implements DeviceService {
             command.setRetryCount(command.getRetryCount() + 1);
             command.setNextRetryAt(now.plus(commandRetryInterval));
             command.setErrorMessage(null);
+            downlinkMetricsRecorder.recordRetried();
+            downlinkMetricsRecorder.recordSent();
         } catch (RuntimeException ex) {
             int nextRetry = command.getRetryCount() + 1;
             command.setRetryCount(nextRetry);
             if (nextRetry >= command.getMaxRetries()) {
                 command.setStatus(DeviceCommandStatus.FAILED);
                 command.setNextRetryAt(null);
+                downlinkMetricsRecorder.recordFailed();
             } else {
                 command.setStatus(DeviceCommandStatus.SENT);
                 command.setNextRetryAt(now.plus(commandRetryInterval));
+                downlinkMetricsRecorder.recordRetried();
             }
             command.setErrorMessage(ex.getMessage());
         }

--- a/src/main/java/com/iot/IoT/service/metrics/DownlinkMetricsRecorder.java
+++ b/src/main/java/com/iot/IoT/service/metrics/DownlinkMetricsRecorder.java
@@ -1,0 +1,49 @@
+package com.iot.IoT.service.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DownlinkMetricsRecorder {
+
+    private final Counter sentCounter;
+    private final Counter failedCounter;
+    private final Counter ackedCounter;
+    private final Counter expiredCounter;
+    private final Counter retriedCounter;
+    private final Counter idempotencyHitCounter;
+
+    public DownlinkMetricsRecorder(MeterRegistry meterRegistry) {
+        this.sentCounter = meterRegistry.counter("iot.downlink.command.sent.total");
+        this.failedCounter = meterRegistry.counter("iot.downlink.command.failed.total");
+        this.ackedCounter = meterRegistry.counter("iot.downlink.command.acked.total");
+        this.expiredCounter = meterRegistry.counter("iot.downlink.command.expired.total");
+        this.retriedCounter = meterRegistry.counter("iot.downlink.command.retried.total");
+        this.idempotencyHitCounter = meterRegistry.counter("iot.downlink.command.idempotency.hit.total");
+    }
+
+    public void recordSent() {
+        sentCounter.increment();
+    }
+
+    public void recordFailed() {
+        failedCounter.increment();
+    }
+
+    public void recordAcked() {
+        ackedCounter.increment();
+    }
+
+    public void recordExpired() {
+        expiredCounter.increment();
+    }
+
+    public void recordRetried() {
+        retriedCounter.increment();
+    }
+
+    public void recordIdempotencyHit() {
+        idempotencyHitCounter.increment();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,3 +54,22 @@ logging:
   level:
     root: INFO
     org.springframework.integration: DEBUG
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      access: unrestricted
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      env: ${APP_ENV:local}

--- a/src/test/java/com/iot/IoT/service/DeviceServiceImplTest.java
+++ b/src/test/java/com/iot/IoT/service/DeviceServiceImplTest.java
@@ -22,6 +22,7 @@ import com.iot.IoT.service.exception.DeviceCommandNotFoundException;
 import com.iot.IoT.service.exception.DeviceNotFoundException;
 import com.iot.IoT.service.exception.DuplicateDeviceException;
 import com.iot.IoT.service.exception.InvalidDeviceQueryException;
+import com.iot.IoT.service.metrics.DownlinkMetricsRecorder;
 import com.iot.IoT.watchdog.port.WatchdogStatePort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -52,6 +53,7 @@ class DeviceServiceImplTest {
     private WatchdogStatePort watchdogStatePort;
     private TemperatureTimeSeriesQueryPort temperatureTimeSeriesQueryPort;
     private DeviceCommandPublisherPort deviceCommandPublisherPort;
+    private DownlinkMetricsRecorder downlinkMetricsRecorder;
     private DeviceServiceImpl deviceService;
 
     @BeforeEach
@@ -61,12 +63,14 @@ class DeviceServiceImplTest {
         watchdogStatePort = Mockito.mock(WatchdogStatePort.class);
         temperatureTimeSeriesQueryPort = Mockito.mock(TemperatureTimeSeriesQueryPort.class);
         deviceCommandPublisherPort = Mockito.mock(DeviceCommandPublisherPort.class);
+        downlinkMetricsRecorder = Mockito.mock(DownlinkMetricsRecorder.class);
         deviceService = new DeviceServiceImpl(
                 deviceRepository,
                 deviceCommandRepository,
                 watchdogStatePort,
                 temperatureTimeSeriesQueryPort,
                 deviceCommandPublisherPort,
+                downlinkMetricsRecorder,
                 120,
                 10,
                 30,


### PR DESCRIPTION
## Summary
  - 변경 배경: Phase 6 Observability 1차(Actuator/Micrometer/Prometheus) 기반 필요
  - 핵심 변경사항:
    - `spring-boot-starter-actuator`, `micrometer-registry-prometheus` 의존성 추가
    - Actuator endpoint 노출 설정 추가 (`health`, `info`, `metrics`, `prometheus`)
    - 공통 metrics tag 설정 추가 (`application`, `env`)
    - Ingestion 메트릭을 Micrometer counter로 연동
    - Downlink 신뢰성 메트릭 recorder 추가 및 서비스 로직 연결
    - 운영 확인 문서 `docs/observability.md` 추가
  - Closes: #37

  ## Why
  - 이 변경이 필요한 이유:
    - 7단계 Grafana 대시보드 및 운영 지표 기반 분석을 위해 표준 metrics endpoint가 선행되어야 함

  ## Changes
  - [ ] Ingestion
  - [x] Control Loop
  - [ ] Watchdog/Fail-safe
  - [x] Infra/Config
  - [x] Docs

  ## Test Evidence
  - 실행 커맨드: `./gradlew test`
  - 결과 요약: (로컬 실행 결과 기입)
  - 로그/스크린샷:
    - `GET /actuator/health` 응답
    - `GET /actuator/prometheus`에서 `iot_*` 메트릭 노출 확인

  ## Risk & Rollback
  - 예상 리스크:
    - 메트릭 수집량 증가로 인한 미세한 오버헤드
    - actuator endpoint 노출 범위 설정 실수 가능성
  - 롤백 방법:
    - 본 PR revert
    - actuator/prometheus 설정 및 의존성 제거로 즉시 복귀 가능

  ## Checklist
  - [x] 관련 이슈 링크를 연결했다.
  - [x] 예외/에러 처리 경로를 점검했다.
  - [x] 테스트를 추가/갱신했다.
  - [x] 성능 영향(고트래픽 관점)을 검토했다.