### PR TITLE
feat(observability): add grafana dashboard and operations runbook

### DIFF
--- a/docs/grafana-observability-dashboard.json
+++ b/docs/grafana-observability-dashboard.json
@@ -1,0 +1,377 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(iot_ingestion_mqtt_received_total[1m])",
+          "legendFormat": "mqtt recv/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(iot_ingestion_parse_success_total[1m])",
+          "legendFormat": "parse ok/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Ingestion Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(iot_ingestion_parse_failure_total[5m])) / clamp_min(sum(rate(iot_ingestion_parse_success_total[5m]) + rate(iot_ingestion_parse_failure_total[5m])), 1e-9)",
+          "legendFormat": "parse failure ratio",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(iot_ingestion_influx_failure_total[5m])) / clamp_min(sum(rate(iot_ingestion_influx_success_total[5m]) + rate(iot_ingestion_influx_failure_total[5m])), 1e-9)",
+          "legendFormat": "influx failure ratio",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(iot_ingestion_redis_failure_total[5m])) / clamp_min(sum(rate(iot_ingestion_redis_success_total[5m]) + rate(iot_ingestion_redis_failure_total[5m])), 1e-9)",
+          "legendFormat": "redis failure ratio",
+          "refId": "C"
+        }
+      ],
+      "title": "Ingestion Failure Ratios",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(iot_downlink_command_sent_total[1m])",
+          "legendFormat": "sent/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(iot_downlink_command_acked_total[1m])",
+          "legendFormat": "acked/s",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(iot_downlink_command_expired_total[1m])",
+          "legendFormat": "expired/s",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(iot_downlink_command_failed_total[1m])",
+          "legendFormat": "failed/s",
+          "refId": "D"
+        },
+        {
+          "expr": "rate(iot_downlink_command_retried_total[1m])",
+          "legendFormat": "retried/s",
+          "refId": "E"
+        }
+      ],
+      "title": "Downlink Command Events",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(iot_downlink_command_acked_total[5m])) / clamp_min(sum(rate(iot_downlink_command_sent_total[5m])), 1e-9)",
+          "legendFormat": "acked ratio",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(iot_downlink_command_expired_total[5m])) / clamp_min(sum(rate(iot_downlink_command_sent_total[5m])), 1e-9)",
+          "legendFormat": "timeout ratio",
+          "refId": "B"
+        }
+      ],
+      "title": "Downlink Reliability Ratios",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(jvm_memory_used_bytes{area=\"heap\"})",
+          "legendFormat": "heap used",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(jvm_memory_max_bytes{area=\"heap\"})",
+          "legendFormat": "heap max",
+          "refId": "B"
+        }
+      ],
+      "title": "JVM Heap Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "process_cpu_usage",
+          "legendFormat": "cpu usage",
+          "refId": "A"
+        },
+        {
+          "expr": "jvm_threads_live_threads",
+          "legendFormat": "live threads",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(http_server_requests_seconds_count[1m])",
+          "legendFormat": "http req/s",
+          "refId": "C"
+        }
+      ],
+      "title": "System Runtime Overview",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "iot",
+    "observability",
+    "phase-7"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "IoT Observability Overview (Phase 7)",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -42,3 +42,14 @@ curl -s http://localhost:8080/actuator/prometheus | rg "^iot\\."
 ## Common Tags
 - `application`: `${spring.application.name}`
 - `env`: `${APP_ENV:local}`
+
+## Grafana (Phase 7)
+- Dashboard JSON:
+  - `docs/grafana-observability-dashboard.json`
+- Runbook:
+  - `docs/operations-runbook.md`
+
+## Quick Import
+1. Grafana > Dashboards > Import
+2. `docs/grafana-observability-dashboard.json` 업로드
+3. datasource 변수(`DS_PROMETHEUS`)를 Prometheus에 매핑

--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -1,0 +1,70 @@
+# Operations Runbook (Phase 7)
+
+## Purpose
+- Grafana 대시보드를 기준으로 ingestion/downlink 이상 징후를 빠르게 분류하고 대응한다.
+
+## Prerequisites
+1. 앱 실행 상태
+2. Prometheus가 `/actuator/prometheus` 스크랩 중
+3. Grafana datasource(`Prometheus`) 연결 완료
+
+## Dashboard Import
+1. Grafana > Dashboards > Import
+2. `docs/grafana-observability-dashboard.json` 업로드
+3. `DS_PROMETHEUS`에 Prometheus datasource 매핑
+
+## Triage Flow
+1. Ingestion Throughput 확인
+- `mqtt recv/s` 급감 여부 확인
+
+2. Ingestion Failure Ratios 확인
+- `parse failure ratio` 상승 시 payload/스키마 변경 의심
+- `influx failure ratio` 상승 시 Influx 연결/토큰/지연 점검
+- `redis failure ratio` 상승 시 Redis 연결/메모리 점검
+
+3. Downlink Command Events 확인
+- `failed/s`, `expired/s`, `retried/s` 급증 여부 확인
+
+4. Downlink Reliability Ratios 확인
+- `acked ratio` 하락 + `timeout ratio` 상승이면 디바이스 ACK 경로 또는 네트워크 지연 우선 점검
+
+5. System Runtime Overview 확인
+- CPU 급등, thread 증가, HTTP req/s 급증 여부 확인
+
+## Incident Scenarios
+### 1) Parse Failure 급증
+- 증상: `parse failure ratio` > 1%
+- 점검:
+  - 최근 payload 포맷 변경 여부
+  - enum/string 필드 값 변경 여부
+  - 배포 직후 발생인지 확인
+- 조치:
+  - 파서 유효성 규칙과 송신 포맷 동기화
+
+### 2) Downlink Timeout 급증
+- 증상: `timeout ratio` 상승, `acked ratio` 하락
+- 점검:
+  - ACK endpoint 트래픽 유입 여부
+  - 명령 topic 발행 성공 여부(`sent/s` 대비 `acked/s`)
+  - retry 증가 동반 여부
+- 조치:
+  - ACK 경로 우선 복구
+  - 필요 시 `downlink.ack-timeout-seconds`, `downlink.retry-interval-seconds` 조정
+
+### 3) Downlink Failed 급증
+- 증상: `failed/s` 급증
+- 점검:
+  - MQTT broker 연결 상태
+  - 인증/토픽 권한 설정
+  - 앱 로그의 publish exception 확인
+- 조치:
+  - broker 연결/인증 복구 후 재시도
+
+## Suggested Thresholds (Initial)
+- parse failure ratio: `> 0.01` (1%)
+- timeout ratio: `> 0.05` (5%)
+- downlink failed/s: 평시 대비 3배 이상
+
+## Related Docs
+- `docs/observability.md`
+- `docs/device-api.md`


### PR DESCRIPTION
## Summary
  - 변경 배경: Observability 1차(Actuator/Micrometer/Prometheus)와 운영 시각화(Grafana/Runbook)를 완성하기 위함
  - 핵심 변경사항:
    - Actuator + Prometheus 의존성/설정 추가
    - ingestion/downlink 메트릭 계측 추가
    - Grafana dashboard JSON 추가
    - 운영 Runbook 문서 추가
    - observability 문서에 대시보드/런북 연결
  - Closes: #39 

  ## Why
  - 이 변경이 필요한 이유:
    - 기능 구현뿐 아니라 운영 상태를 계측/시각화/대응 가능한 구조로 만들기 위함

  ## Changes
  - [x] Ingestion
  - [x] Control Loop
  - [ ] Watchdog/Fail-safe
  - [x] Infra/Config
  - [x] Docs

  ## Test Evidence
  - 실행 커맨드: `./gradlew test`
  - 결과 요약: (로컬 실행 결과 기입)
  - 로그/스크린샷:
    - `/actuator/health`
    - `/actuator/prometheus`에서 `iot_*` 메트릭 노출
    - Grafana 대시보드 패널 캡처

  ## Risk & Rollback
  - 예상 리스크:
    - 메트릭 계측 증가로 인한 소량 오버헤드
    - endpoint 노출 설정 실수 가능성
  - 롤백 방법:
    - 본 PR revert
    - actuator/prometheus 관련 설정/의존성 제거

  ## Checklist
  - [x] 관련 이슈 링크를 연결했다.
  - [x] 예외/에러 처리 경로를 점검했다.
  - [x] 테스트를 추가/갱신했다.
  - [x] 성능 영향(고트래픽 관점)을 검토했다.