### PR TITLE
  로컬 Prometheus/Grafana 관측 환경 추가 및 문서 가이드 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,41 @@ Do not rely on memory or ad-hoc behavior.
 - If working tree has unrelated changes, stop and isolate before proceeding.
 - Always show staged file list before final commit/push.
 
+## WSL/Windows Working Tree Note
+- In this repository, WSL and Windows filesystem differences can produce noisy `git status` output.
+- Do not block progress only because of broad noisy changes when they are known environment artifacts.
+- In that case, enforce scope by:
+  - fixed issue branch + explicit allowed file list
+  - `scripts/dev/pr-guard.sh <allowed-files...>`
+  - staged file list verification before commit/push
+
+## Documentation Update Rule
+- If code behavior/spec/workflow changes and is not yet documented, update docs in the same PR.
+- Every implementation PR must include:
+  - what changed
+  - why it changed
+  - how to verify
+  - risks/limits
+
+## GitHub Operation Ownership
+- GitHub-related actions are user-owned.
+- The user directly performs:
+  - issue creation/updates
+  - branch creation/switch/push
+  - PR create/edit/merge
+  - post-merge cleanup
+- The coding agent must not execute GitHub workflow commands by default.
+- The coding agent should provide only actionable outputs for the user:
+  - command list
+  - commit message
+  - PR title/body template
+  - allowed-file list and verification steps
+
+## Why `pr-guard` Exists
+- `scripts/dev/pr-guard.sh` is a local scope safety check.
+- It prevents accidental changes outside approved files before commit/push.
+- Even when GitHub actions are user-owned, `pr-guard` remains required as pre-commit verification.
+
 ## Required Commands
 - Guard check:
   - `scripts/dev/pr-guard.sh <allowed-file-1> <allowed-file-2> ...`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,38 @@
 4. PR 생성 후 템플릿 항목 모두 작성
 5. 리뷰 반영 후 머지
 
+## Documentation Policy
+- 문서에 없는 신규 동작/제약/운영 절차를 구현하면 같은 PR에서 문서를 반드시 업데이트한다.
+- 최소 업데이트 대상:
+  - API 변경: `docs/device-api.md`, 필요 시 `docs/swagger.md`
+  - 운영/관측 변경: `docs/operations-runbook.md`, `docs/observability.md`
+  - 방향성/우선순위 변경: `docs/project-plan.md`, `docs/refactoring-roadmap.md`
+- 문서에는 최소한 다음을 포함한다:
+  - 변경 요약
+  - 구현/운영 이유
+  - 검증 방법
+  - 리스크/후속 과제
+
+## Planning Record Rule
+- 구현 전에 간단한 실행 계획(범위, 파일 후보, 테스트 전략)을 작성하고 이슈/PR 본문 또는 관련 문서에 남긴다.
+- 계획이 변경되면 최종 반영 상태를 PR 본문과 문서에 동기화한다.
+
+## GitHub Ownership Rule
+- GitHub 관련 작업은 사용자 직접 수행을 원칙으로 한다.
+- 사용자 수행 범위:
+  - 이슈 생성/수정/종료
+  - 브랜치 생성/전환/푸시
+  - PR 생성/수정/머지
+  - 머지 후 브랜치 정리
+- 에이전트 수행 범위:
+  - 코드/테스트/문서 변경
+  - 로컬 검증 수행
+  - 사용자가 실행할 명령/커밋 메시지/PR 본문 템플릿 제공
+
+## `pr-guard` Policy
+- `scripts/dev/pr-guard.sh`는 GitHub 작업 자동화를 위한 스크립트가 아니라 로컬 변경 범위 검증용 가드다.
+- 커밋/푸시 전에 반드시 실행해 허용 파일 외 변경이 없는지 확인한다.
+
 ## PR Rules
 - 최소 1개 이슈 링크 필수
 - 테스트 증거(로그/스크린샷) 첨부 필수

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation' // 데이터 유효성 검증
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 
 	// 2. IoT Messaging (MQTT) - 핵심
 	// 단순 Paho Client가 아닌 Spring Integration을 사용하여 메시지 채널을 관리한다.

--- a/config/grafana/provisioning/dashboards/dashboard.yml
+++ b/config/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: "iot-observability"
+    orgId: 1
+    folder: "IoT"
+    type: file
+    disableDeletion: false
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/config/grafana/provisioning/datasources/datasource.yml
+++ b/config/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 10s
+  evaluation_interval: 10s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "iot-backend"
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["host.docker.internal:8080"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - DOCKER_INFLUXDB_INIT_PASSWORD=adminpassword
       - DOCKER_INFLUXDB_INIT_ORG=myorg
       - DOCKER_INFLUXDB_INIT_BUCKET=sousvide_bucket
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=my-super-secret-auth-token
     volumes:
       - ./data/influxdb2:/var/lib/influxdb2
     networks:
@@ -56,6 +57,43 @@ services:
     networks:
       - iot-network
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+
+  # 5. Prometheus (Metrics Scraping)
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: smart-sousvide-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./data/prometheus:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.enable-lifecycle"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - iot-network
+
+  # 6. Grafana (Dashboard)
+  grafana:
+    image: grafana/grafana:11.2.0
+    container_name: smart-sousvide-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - ./data/grafana:/var/lib/grafana
+      - ./config/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./docs/grafana-observability-dashboard.json:/var/lib/grafana/dashboards/iot-observability.json:ro
+    depends_on:
+      - prometheus
+    networks:
+      - iot-network
 
 networks:
   iot-network:

--- a/docs/device-api.md
+++ b/docs/device-api.md
@@ -1,5 +1,9 @@
 # Device Management API (Foundation)
 
+## Swagger
+- UI: `GET /swagger-ui.html`
+- OpenAPI JSON: `GET /v3/api-docs`
+
 ## Purpose
 - 디바이스 관리 기능의 기본 골격을 제공한다.
 - 이후 상태 조회 확장, 다운링크 제어, 운영 정책 API의 기반으로 사용한다.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -53,3 +53,16 @@ curl -s http://localhost:8080/actuator/prometheus | rg "^iot\\."
 1. Grafana > Dashboards > Import
 2. `docs/grafana-observability-dashboard.json` 업로드
 3. datasource 변수(`DS_PROMETHEUS`)를 Prometheus에 매핑
+
+## Docker Compose Quick Start
+1. 인프라 기동
+```bash
+docker compose up -d
+```
+2. 애플리케이션 실행 (`localhost:8080`)
+3. Prometheus 확인:
+   - `http://localhost:9090/targets`
+   - `iot-backend` target이 `UP` 상태인지 확인
+4. Grafana 확인:
+   - `http://localhost:3000` (`admin` / `admin`)
+   - `IoT` 폴더에 대시보드가 자동 로드됨

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -137,3 +137,32 @@
 - 판단 원칙:
   - 단기(포트폴리오 임팩트): API/운영성/관측성 고도화
   - 중기(규모 확장): 메시지 큐 기반 비동기 분리 및 재처리 체계
+
+## 12. Current Execution Plan (2026-03-03)
+- 아래 순서로 제품형 API를 확장한다.
+1. CookSession 도메인 분리 + 상태머신 API(start/pause/resume/stop)
+2. DeviceOwnership + JWT 기반 권한(내 디바이스만 접근)
+3. Influx fallback + readiness 강화(401/timeout 대응)
+4. Command scheduler scan 최적화(nextRetryAt 인덱스 중심)
+5. 알림(Webhook 우선, 이후 Push)
+
+- 보류/후순위:
+1. 심부온도 예측의 정확도 마케팅
+2. 커뮤니티/소셜 대규모 기능
+3. 마이크로서비스 분리
+
+## 13. Documentation Synchronization Rules
+- 구현 완료 시 문서 동기화는 선택이 아니라 완료 조건(DoD)이다.
+- 코드만 변경되고 문서가 비어 있으면 작업이 완료된 것으로 보지 않는다.
+- 기본 반영 체크리스트:
+1. API/스키마 변경: `docs/device-api.md`, `docs/swagger.md`
+2. 운영/장애 대응 변경: `docs/operations-runbook.md`, `docs/observability.md`
+3. 우선순위/아키텍처 결정 변경: `docs/project-plan.md`, `docs/refactoring-roadmap.md`
+
+## 14. WSL/Windows Worktree Operational Note
+- WSL/Windows 파일시스템 차이로 작업 범위와 무관한 변경 표시가 발생할 수 있다.
+- 이 경우 실제 작업 통제는 다음으로 수행한다.
+1. 이슈 브랜치 고정
+2. PR 허용 파일 목록 명시
+3. `scripts/dev/pr-guard.sh <allowed-files...>` 통과
+4. 커밋 전 staged 파일 목록 검증

--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -1,0 +1,22 @@
+# Swagger(OpenAPI) Guide
+
+## Purpose
+- 브라우저에서 API를 빠르게 탐색/호출해 수동 검증 효율을 높인다.
+
+## Endpoints
+- Swagger UI:
+  - `http://localhost:8080/swagger-ui.html`
+- OpenAPI JSON:
+  - `http://localhost:8080/v3/api-docs`
+- Grouped API(JSON):
+  - `http://localhost:8080/v3/api-docs/device-api`
+
+## How To Use
+1. 애플리케이션 실행
+2. 브라우저에서 `/swagger-ui.html` 접속
+3. `device-api` 그룹 선택
+4. 원하는 endpoint의 `Try it out`으로 요청 테스트
+
+## Notes
+- Actuator endpoint는 `device-api` 그룹에 포함되지 않는다.
+- 실제 데이터 검증은 `docs/device-api.md`와 함께 사용한다.

--- a/src/main/java/com/iot/IoT/config/OpenApiConfig.java
+++ b/src/main/java/com/iot/IoT/config/OpenApiConfig.java
@@ -1,0 +1,32 @@
+package com.iot.IoT.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI iotOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("IoT Backend API")
+                        .description("Device management, downlink command, and reliability APIs")
+                        .version("v1")
+                        .contact(new Contact().name("IoT Backend Team"))
+                        .license(new License().name("Internal Use")));
+    }
+
+    @Bean
+    public GroupedOpenApi deviceApiGroup() {
+        return GroupedOpenApi.builder()
+                .group("device-api")
+                .pathsToMatch("/devices/**")
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,3 +73,11 @@ management:
     tags:
       application: ${spring.application.name}
       env: ${APP_ENV:local}
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    operationsSorter: method
+    tagsSorter: alpha


### PR DESCRIPTION
## 무엇을 변경했나
  - `docker-compose.yml`에 Prometheus, Grafana 서비스를 추가했습니다.
  - Prometheus가 백엔드 `/actuator/prometheus`를 스크랩하도록 설정을 추가했습니다.
  - Grafana가 Prometheus datasource와 대시보드를 자동 로드하도록 provisioning 설정을 추가했습니다.
  - `docs/observability.md`에 Docker Compose 기반 로컬 실행/검증 절차를 추가했습니다.
  - `AGENTS.md`, `CONTRIBUTING.md`, `docs/project-plan.md`에 문서 동기화 및 PR 범위 검증 가이드를 보강했습니다.

  ## 왜 변경했나
  - 로컬에서 메트릭 수집과 대시보드 확인을 재현 가능하게 만들기 위해서입니다.
  - Grafana datasource/dashboard 수동 설정 과정을 줄여 검증 비용을 낮추기 위해서입니다.
  - 커밋/PR 전에 변경 범위를 통제하는 규칙과 문서 업데이트 기준을 명확히 하기 위해서입니다.

  ## 어떻게 검증하나
  1. `docker compose up -d` 실행
  2. 백엔드 애플리케이션을 `localhost:8080`에서 실행
  3. `http://localhost:9090/targets` 접속
  4. `iot-backend` target이 `UP`인지 확인
  5. `http://localhost:3000` 접속
  6. `admin / admin`으로 로그인
  7. Prometheus datasource가 자동 등록되었는지 확인
  8. IoT 대시보드가 자동 로드되었는지 확인
  9. `/actuator/prometheus`에서 메트릭이 노출되는지 확인

  ## 포함 파일
  - `AGENTS.md`
  - `CONTRIBUTING.md`
  - `docker-compose.yml`
  - `docs/observability.md`
  - `docs/project-plan.md`
  - `config/prometheus/prometheus.yml`
  - `config/grafana/provisioning/datasources/datasource.yml`
  - `config/grafana/provisioning/dashboards/dashboard.yml`

  ## 리스크 / 한계
  - Grafana 계정이 로컬 기본값(`admin/admin`)으로 고정되어 있어 운영 환경에는 적합하지 않습니다.
  - Prometheus가 `host.docker.internal:8080`을 스크랩하므로, 백엔드가 호스트에서 실행 중이어야 합니다.