### PR TITLE
feat: complete telemetry-driven auto control loop

### DIFF
--- a/docs/device-api.md
+++ b/docs/device-api.md
@@ -198,6 +198,15 @@
   - `retry-interval`: `10s` (기본값)
   - `max-retries`: `3` (기본값)
 
+## Auto Control Notes (Phase 1)
+- telemetry ingestion 경로에서 제어 판단 결과가 자동 downlink command로 연결된다.
+- 자동 발행 규칙:
+  - `HOLD`는 발행하지 않는다.
+  - 등록되고 `enabled=true`인 디바이스만 자동 발행 대상이다.
+  - 중복 발행 방지를 위해 시간 버킷 기반 idempotency key를 사용한다.
+- 자동 발행 key 예시:
+  - `auto:SV-001:HEAT_ON:<bucket>`
+
 ## Error Response Contract
 ```json
 {

--- a/docs/refactoring-roadmap.md
+++ b/docs/refactoring-roadmap.md
@@ -46,6 +46,17 @@
 3. Observability Standardization
 4. Queue-based Decoupling (Kafka/RabbitMQ + DLQ)
 
+## Phase 1 Update
+- 현재 구현 상태:
+  - telemetry -> control decision -> auto downlink command 연결
+  - `HOLD` 미발행 정책
+  - enabled device 대상 자동 발행
+  - 시간 버킷 기반 idempotency key로 중복 발행 억제
+- 남은 보강:
+  - device ACK topic/payload 표준화
+  - 자동 제어와 수동 제어 우선순위 정책
+  - 장시간 대량 telemetry 환경에서 auto-control dedup window 튜닝
+
 ## 5. Phase Details
 ## Phase 1: Device Management API
 - 목표:

--- a/src/main/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImpl.java
+++ b/src/main/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImpl.java
@@ -6,6 +6,7 @@ import com.iot.IoT.ingestion.dto.DeviceStatusMessage;
 import com.iot.IoT.ingestion.metrics.IngestionMetricsCollector;
 import com.iot.IoT.ingestion.port.HeartbeatPort;
 import com.iot.IoT.ingestion.port.TemperatureTimeSeriesPort;
+import com.iot.IoT.service.DeviceService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,6 +24,7 @@ public class DeviceIngestionServiceImpl implements DeviceIngestionService {
     private final HeartbeatPort heartbeatPort;
     private final ControlDecisionEngine controlDecisionEngine;
     private final IngestionMetricsCollector ingestionMetricsCollector;
+    private final DeviceService deviceService;
     private final String influxWriteMode;
 
     public DeviceIngestionServiceImpl(
@@ -30,12 +32,14 @@ public class DeviceIngestionServiceImpl implements DeviceIngestionService {
             HeartbeatPort heartbeatPort,
             ControlDecisionEngine controlDecisionEngine,
             IngestionMetricsCollector ingestionMetricsCollector,
+            DeviceService deviceService,
             @Value("${ingestion.influx.write-mode:strict}") String influxWriteMode
     ) {
         this.temperatureTimeSeriesPort = temperatureTimeSeriesPort;
         this.heartbeatPort = heartbeatPort;
         this.controlDecisionEngine = controlDecisionEngine;
         this.ingestionMetricsCollector = ingestionMetricsCollector;
+        this.deviceService = deviceService;
         this.influxWriteMode = influxWriteMode;
     }
 
@@ -75,6 +79,7 @@ public class DeviceIngestionServiceImpl implements DeviceIngestionService {
                 message.targetTemp(),
                 message.state(),
                 action);
+        deviceService.sendAutoControlCommand(message.deviceId(), action, now);
     }
 
     private boolean isInfluxWriteBypassMode() {

--- a/src/main/java/com/iot/IoT/repository/DeviceRepository.java
+++ b/src/main/java/com/iot/IoT/repository/DeviceRepository.java
@@ -3,7 +3,11 @@ package com.iot.IoT.repository;
 import com.iot.IoT.entity.Device;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface DeviceRepository extends JpaRepository<Device, Long> {
 
     boolean existsByDeviceId(String deviceId);
+
+    Optional<Device> findByDeviceId(String deviceId);
 }

--- a/src/main/java/com/iot/IoT/service/DeviceService.java
+++ b/src/main/java/com/iot/IoT/service/DeviceService.java
@@ -37,5 +37,7 @@ public interface DeviceService {
 
     DeviceCommandResponse acknowledgeCommand(Long id, Long commandId);
 
+    void sendAutoControlCommand(String deviceId, ControlAction commandType, Instant decidedAt);
+
     void processCommandReliability();
 }

--- a/src/main/java/com/iot/IoT/service/DeviceServiceImpl.java
+++ b/src/main/java/com/iot/IoT/service/DeviceServiceImpl.java
@@ -61,6 +61,7 @@ public class DeviceServiceImpl implements DeviceService {
     private final Duration heartbeatTtl;
     private final Duration commandRetryInterval;
     private final Duration commandAckTimeout;
+    private final Duration autoControlDedupWindow;
     private final int commandMaxRetries;
 
     public DeviceServiceImpl(
@@ -73,6 +74,7 @@ public class DeviceServiceImpl implements DeviceService {
             @Value("${ingestion.heartbeat-ttl-seconds:120}") long heartbeatTtlSeconds,
             @Value("${downlink.retry-interval-seconds:10}") long commandRetryIntervalSeconds,
             @Value("${downlink.ack-timeout-seconds:30}") long commandAckTimeoutSeconds,
+            @Value("${control.auto-command-dedup-window-seconds:30}") long autoControlDedupWindowSeconds,
             @Value("${downlink.max-retries:3}") int commandMaxRetries
     ) {
         this.deviceRepository = deviceRepository;
@@ -84,6 +86,7 @@ public class DeviceServiceImpl implements DeviceService {
         this.heartbeatTtl = Duration.ofSeconds(heartbeatTtlSeconds);
         this.commandRetryInterval = Duration.ofSeconds(commandRetryIntervalSeconds);
         this.commandAckTimeout = Duration.ofSeconds(commandAckTimeoutSeconds);
+        this.autoControlDedupWindow = Duration.ofSeconds(Math.max(autoControlDedupWindowSeconds, 1));
         this.commandMaxRetries = Math.max(commandMaxRetries, 0);
     }
 
@@ -290,6 +293,27 @@ public class DeviceServiceImpl implements DeviceService {
 
     @Override
     @Transactional
+    public void sendAutoControlCommand(String deviceId, ControlAction commandType, Instant decidedAt) {
+        if (commandType == ControlAction.HOLD) {
+            return;
+        }
+
+        String normalizedDeviceId = normalize(deviceId);
+        if (normalizedDeviceId == null || normalizedDeviceId.isBlank()) {
+            return;
+        }
+
+        Optional<Device> device = deviceRepository.findByDeviceId(normalizedDeviceId);
+        if (device.isEmpty() || !device.get().isEnabled()) {
+            return;
+        }
+
+        String idempotencyKey = buildAutoControlIdempotencyKey(normalizedDeviceId, commandType, decidedAt);
+        sendCommand(device.get().getId(), commandType, idempotencyKey);
+    }
+
+    @Override
+    @Transactional
     public void processCommandReliability() {
         Instant now = Instant.now();
         List<DeviceCommand> targets = deviceCommandRepository.findByStatusIn(RELIABILITY_TARGET_STATUSES);
@@ -444,6 +468,11 @@ public class DeviceServiceImpl implements DeviceService {
         return """
                 {"commandId":%d,"commandType":"%s","requestedAt":"%s"}
                 """.formatted(commandId, commandType.name(), requestedAt.toString()).trim();
+    }
+
+    private String buildAutoControlIdempotencyKey(String deviceId, ControlAction commandType, Instant decidedAt) {
+        long dedupBucket = decidedAt.toEpochMilli() / autoControlDedupWindow.toMillis();
+        return "auto:%s:%s:%d".formatted(deviceId, commandType.name(), dedupBucket);
     }
 
     private Range resolveRange(Instant from, Instant to) {

--- a/src/test/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImplTest.java
+++ b/src/test/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImplTest.java
@@ -6,6 +6,8 @@ import com.iot.IoT.ingestion.dto.DeviceStatusMessage;
 import com.iot.IoT.ingestion.metrics.IngestionMetricsCollector;
 import com.iot.IoT.ingestion.port.HeartbeatPort;
 import com.iot.IoT.ingestion.port.TemperatureTimeSeriesPort;
+import com.iot.IoT.control.ControlAction;
+import com.iot.IoT.service.DeviceService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class DeviceIngestionServiceImplTest {
 
@@ -29,6 +32,7 @@ class DeviceIngestionServiceImplTest {
     private HeartbeatPort heartbeatPort;
     private ControlDecisionEngine controlDecisionEngine;
     private IngestionMetricsCollector ingestionMetricsCollector;
+    private DeviceService deviceService;
     private DeviceIngestionServiceImpl service;
 
     @BeforeEach
@@ -37,7 +41,9 @@ class DeviceIngestionServiceImplTest {
         heartbeatPort = Mockito.mock(HeartbeatPort.class);
         controlDecisionEngine = Mockito.mock(ControlDecisionEngine.class);
         ingestionMetricsCollector = Mockito.mock(IngestionMetricsCollector.class);
+        deviceService = Mockito.mock(DeviceService.class);
         service = createService(INFLUX_MODE_STRICT);
+        when(controlDecisionEngine.decide(any())).thenReturn(ControlAction.HEAT_ON);
     }
 
     @Test
@@ -54,6 +60,7 @@ class DeviceIngestionServiceImplTest {
         verify(ingestionMetricsCollector, times(1)).recordRedisSuccess();
         verify(ingestionMetricsCollector, times(0)).recordRedisFailure();
         verify(controlDecisionEngine, times(1)).decide(eq(message));
+        verify(deviceService, times(1)).sendAutoControlCommand(eq("SV-001"), any(), any());
     }
 
     @Test
@@ -71,6 +78,7 @@ class DeviceIngestionServiceImplTest {
         verify(ingestionMetricsCollector, times(1)).recordRedisSuccess();
         verify(ingestionMetricsCollector, times(0)).recordRedisFailure();
         verify(controlDecisionEngine, times(1)).decide(eq(message));
+        verify(deviceService, times(1)).sendAutoControlCommand(eq("SV-001"), any(), any());
     }
 
     @Test
@@ -88,6 +96,7 @@ class DeviceIngestionServiceImplTest {
         verify(ingestionMetricsCollector, times(0)).recordRedisSuccess();
         verify(ingestionMetricsCollector, times(1)).recordRedisFailure();
         verify(controlDecisionEngine, times(1)).decide(eq(message));
+        verify(deviceService, times(1)).sendAutoControlCommand(eq("SV-001"), any(), any());
     }
 
     @Test
@@ -106,6 +115,7 @@ class DeviceIngestionServiceImplTest {
         verify(ingestionMetricsCollector, times(1)).recordRedisSuccess();
         verify(ingestionMetricsCollector, never()).recordRedisFailure();
         verify(controlDecisionEngine, times(1)).decide(eq(message));
+        verify(deviceService, times(1)).sendAutoControlCommand(eq("SV-001"), any(), any());
     }
 
     @Test
@@ -125,6 +135,7 @@ class DeviceIngestionServiceImplTest {
         verify(ingestionMetricsCollector, never()).recordRedisSuccess();
         verify(ingestionMetricsCollector, times(1)).recordRedisFailure();
         verify(controlDecisionEngine, times(1)).decide(eq(message));
+        verify(deviceService, times(1)).sendAutoControlCommand(eq("SV-001"), any(), any());
     }
 
     private DeviceStatusMessage sampleMessage() {
@@ -142,6 +153,7 @@ class DeviceIngestionServiceImplTest {
                 heartbeatPort,
                 controlDecisionEngine,
                 ingestionMetricsCollector,
+                deviceService,
                 influxWriteMode
         );
     }

--- a/src/test/java/com/iot/IoT/service/DeviceServiceImplTest.java
+++ b/src/test/java/com/iot/IoT/service/DeviceServiceImplTest.java
@@ -74,6 +74,7 @@ class DeviceServiceImplTest {
                 120,
                 10,
                 30,
+                30,
                 3
         );
     }
@@ -395,6 +396,63 @@ class DeviceServiceImplTest {
         when(deviceCommandRepository.findByIdAndDevicePk(12L, 1L)).thenReturn(Optional.empty());
 
         assertThrows(DeviceCommandNotFoundException.class, () -> deviceService.acknowledgeCommand(1L, 12L));
+    }
+
+    @Test
+    @DisplayName("Should publish auto control command for enabled device")
+    void sendAutoControlCommand_enabledDevice() {
+        Device device = sampleDevice(1L, "SV-001", true);
+        when(deviceRepository.findByDeviceId("SV-001")).thenReturn(Optional.of(device));
+        when(deviceRepository.findById(1L)).thenReturn(Optional.of(device));
+        when(deviceCommandRepository.findByDevicePkAndIdempotencyKey(eq(1L), any())).thenReturn(Optional.empty());
+        when(deviceCommandRepository.save(any(DeviceCommand.class)))
+                .thenAnswer(invocation -> {
+                    DeviceCommand command = invocation.getArgument(0);
+                    if (command.getId() == null) {
+                        setId(command, 21L);
+                    }
+                    if (command.getRequestedAt() == null) {
+                        command.setRequestedAt(Instant.parse("2026-03-02T00:00:00Z"));
+                    }
+                    return command;
+                });
+
+        deviceService.sendAutoControlCommand(
+                "SV-001",
+                ControlAction.HEAT_ON,
+                Instant.parse("2026-03-02T00:00:05Z")
+        );
+
+        verify(deviceCommandPublisherPort, times(1)).publish(eq("devices/SV-001/cmd"), any(String.class));
+    }
+
+    @Test
+    @DisplayName("Should skip auto control command for disabled device")
+    void sendAutoControlCommand_disabledDevice() {
+        Device device = sampleDevice(1L, "SV-001", false);
+        when(deviceRepository.findByDeviceId("SV-001")).thenReturn(Optional.of(device));
+
+        deviceService.sendAutoControlCommand(
+                "SV-001",
+                ControlAction.HEAT_ON,
+                Instant.parse("2026-03-02T00:00:05Z")
+        );
+
+        verify(deviceCommandPublisherPort, never()).publish(any(String.class), any(String.class));
+        verify(deviceCommandRepository, never()).save(any(DeviceCommand.class));
+    }
+
+    @Test
+    @DisplayName("Should skip auto control hold action")
+    void sendAutoControlCommand_holdAction() {
+        deviceService.sendAutoControlCommand(
+                "SV-001",
+                ControlAction.HOLD,
+                Instant.parse("2026-03-02T00:00:05Z")
+        );
+
+        verify(deviceRepository, never()).findByDeviceId(any());
+        verify(deviceCommandPublisherPort, never()).publish(any(String.class), any(String.class));
     }
 
     @Test


### PR DESCRIPTION
## What Changed
  - telemetry ingestion 이후 제어 결정 결과를 자동 downlink command 발행으로 연결
  - `DeviceService`에 자동 제어 command 발행 유스케이스 추가
  - 등록되고 `enabled=true`인 디바이스만 자동 발행 대상이 되도록 처리
  - `HOLD` 액션은 자동 발행하지 않도록 정책 반영
  - 시간 버킷 기반 idempotency key를 적용해 자동 제어 command 중복 발행 억제
  - 관련 service/ingestion 테스트 추가
  - device API 및 roadmap 문서에 자동 제어 정책 반영

  ## Why
  - 기존 구현은 telemetry를 받아 제어 결정을 계산만 하고 실제 command 발행까지는 이어지지 않았음
  - 포트폴리오/면접 관점에서 “제어 로직이 실제 운영 흐름으로 연결되는가”를 설명하기 위해 폐루프 완성이 필요했음
  - 자동 제어에서 가장 먼저 필요한 안전장치인 발행 조건과 dedup 정책을 함께 반영했음

  ## How To Verify
  - 테스트 실행
  ```bash
  ./gradlew test

  - 확인 포인트
      - telemetry ingestion 시 제어 결정 후 자동 command 발행 경로가 호출되는지
      - HOLD는 자동 발행되지 않는지
      - disabled device는 자동 발행 대상에서 제외되는지
      - 자동 제어 command가 기존 downlink 발행 흐름과 동일하게 저장/발행되는지

  ## Risks / Limits

  - ACK topic/payload 표준은 아직 문서 수준으로 완전히 정리되지 않았음
  - 자동 제어와 수동 command 발행 간 우선순위 정책은 아직 없음
  - dedup window는 기본값 기반이며 실제 대량 telemetry 환경에서는 추가 튜닝이 필요함
  
close #43 