### PR TITLE
refactor: improve ingestion isolation and observability

### DIFF
--- a/docs/load-test-results.md
+++ b/docs/load-test-results.md
@@ -166,3 +166,13 @@ Use the same split-table schema above for PR2 rows, with `Influx Bypass` and `Bu
   - connection success and throughput
   - business overall/core success split
   - parse/influx/redis failure counters and bypass count
+
+## Phase 2 Baseline Change
+- Backend ingestion path now uses executor-backed dispatch instead of direct synchronous channel handoff.
+- Additional metrics were added to classify backend saturation:
+  - `processing_failure_total`
+  - `overall_pipeline_success_total`
+  - `core_pipeline_success_total`
+  - `inflight`
+  - ingestion processing latency timer
+- Re-run the 5k HiveMQ validation after this change and append strict/bypass comparison rows with the updated metric set.

--- a/docs/load-test-scenarios.md
+++ b/docs/load-test-scenarios.md
@@ -12,6 +12,9 @@ Run with at least Mosquitto up:
 - Use `scripts/loadtest/run-distributed.sh`.
 - Script does one-time runtime preparation, then runs each partition via direct `java -cp ...` execution.
 - This avoids per-partition Gradle startup overhead.
+- Backend Phase 2 baseline:
+  - MQTT inbound uses executor-backed channel instead of single-thread handoff.
+  - Observe `inflight`, `processing_latency`, `overall/core pipeline success` together.
 
 ## Common Arguments
 ```bash
@@ -108,6 +111,9 @@ Expected artifacts:
 - `redis_ok_total`, `redis_fail_total`
 - `pipeline_success_total` (overall)
 - `core_pipeline_success_total` (parse+redis)
+- `processing_failure_total`
+- `inflight` peak
+- processing latency (`p95` when available)
 - per-part logs: `docs/loadtest-runs/<run-id>/attempt-<n>/part-*.log`
 - failure signatures:
   - `unable to create native thread`
@@ -122,6 +128,10 @@ Split aggregation formulas:
 - connection success rate = `published_total / (published_total + failed_total)`
 - business pipeline success rate = `min(parse_ok_total, influx_ok_total, redis_ok_total) / recv_total`
 - business core pipeline success rate = `min(parse_ok_total, redis_ok_total) / recv_total`
+
+Interpretation note:
+- `overall` down with relatively stable `core` means Influx path is the primary bottleneck candidate.
+- `inflight` growth with latency increase means downstream processing saturation/backlog.
 
 ## Service Objectives (SLO)
 - Ingestion success rate: `>= 99.9%`

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -31,6 +31,11 @@ curl -s http://localhost:8080/actuator/prometheus | rg "^iot\\."
   - `iot_ingestion_influx_bypass_total`
   - `iot_ingestion_redis_success_total`
   - `iot_ingestion_redis_failure_total`
+  - `iot_ingestion_processing_failure_total`
+  - `iot_ingestion_pipeline_overall_success_total`
+  - `iot_ingestion_pipeline_core_success_total`
+  - `iot_ingestion_inflight`
+  - `iot_ingestion_processing_latency_seconds`
 - Downlink:
   - `iot_downlink_command_sent_total`
   - `iot_downlink_command_failed_total`
@@ -42,6 +47,14 @@ curl -s http://localhost:8080/actuator/prometheus | rg "^iot\\."
 ## Common Tags
 - `application`: `${spring.application.name}`
 - `env`: `${APP_ENV:local}`
+
+## Phase 2 Notes
+- MQTT inbound channel은 executor 기반으로 분리되어 broker 수신 스레드와 downstream 처리 스레드를 느슨하게 분리한다.
+- business success 지표는 아래 두 축으로 본다.
+  - overall pipeline success: parse 이후 Influx + Redis가 모두 성공한 건수
+  - core pipeline success: parse 이후 Redis heartbeat까지 성공한 건수
+- `strict` 모드는 Influx write path를 포함한 전체 경로 검증용이다.
+- `bypass` 모드는 Influx 압력을 제외하고 parse + Redis + control path를 검증하기 위한 모드다.
 
 ## Grafana (Phase 7)
 - Dashboard JSON:

--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -21,14 +21,20 @@
 - `parse failure ratio` 상승 시 payload/스키마 변경 의심
 - `influx failure ratio` 상승 시 Influx 연결/토큰/지연 점검
 - `redis failure ratio` 상승 시 Redis 연결/메모리 점검
+- `processing failure ratio` 상승 시 애플리케이션 내부 예외 또는 executor backlog 의심
 
-3. Downlink Command Events 확인
+3. Ingestion Pipeline Success 확인
+- `overall pipeline success`가 하락하면 Influx 또는 Redis 경로를 우선 의심
+- `core pipeline success`는 유지되고 `overall`만 하락하면 Influx write path 병목 가능성이 높음
+- `inflight`가 계속 상승하면 downstream 처리 속도가 입력 속도를 따라가지 못하는 상태로 본다
+
+4. Downlink Command Events 확인
 - `failed/s`, `expired/s`, `retried/s` 급증 여부 확인
 
-4. Downlink Reliability Ratios 확인
+5. Downlink Reliability Ratios 확인
 - `acked ratio` 하락 + `timeout ratio` 상승이면 디바이스 ACK 경로 또는 네트워크 지연 우선 점검
 
-5. System Runtime Overview 확인
+6. System Runtime Overview 확인
 - CPU 급등, thread 증가, HTTP req/s 급증 여부 확인
 
 ## Incident Scenarios
@@ -60,10 +66,21 @@
 - 조치:
   - broker 연결/인증 복구 후 재시도
 
+### 4) Overall Pipeline Success 급락
+- 증상: `overall pipeline success` 급락, `core pipeline success`는 유지 또는 상대적으로 높음
+- 점검:
+  - InfluxDB 상태 및 write latency
+  - strict / bypass 모드 설정 확인
+  - backend 로그의 Influx write failure 메시지 확인
+- 조치:
+  - 우선 bypass 모드로 core path를 분리 검증
+  - Influx 연결/토큰/스토리지 상태 복구 후 strict 재검증
+
 ## Suggested Thresholds (Initial)
 - parse failure ratio: `> 0.01` (1%)
 - timeout ratio: `> 0.05` (5%)
 - downlink failed/s: 평시 대비 3배 이상
+- inflight: 지속 증가 추세면 backlog 의심
 
 ## Related Docs
 - `docs/observability.md`

--- a/docs/refactoring-roadmap.md
+++ b/docs/refactoring-roadmap.md
@@ -57,6 +57,16 @@
   - 자동 제어와 수동 제어 우선순위 정책
   - 장시간 대량 telemetry 환경에서 auto-control dedup window 튜닝
 
+## Phase 2 Update
+- 현재 구현 상태:
+  - MQTT inbound를 executor 기반으로 분리해 broker 수신 스레드와 downstream 처리 경로를 느슨하게 분리
+  - `overall/core pipeline success`, `processing failure`, `inflight`, processing latency 메트릭 추가
+  - control dispatch 예외가 ingestion 전체 실패로 번지지 않도록 격리
+- 남은 보강:
+  - 5k strict / bypass 재측정 결과 반영
+  - executor pool/queue 튜닝 근거 수치화
+  - backlog 발생 시 후속 큐 분리 전략(DLQ/replay 포함) 결정
+
 ## 5. Phase Details
 ## Phase 1: Device Management API
 - 목표:

--- a/src/main/java/com/iot/IoT/ingestion/config/MqttConfig.java
+++ b/src/main/java/com/iot/IoT/ingestion/config/MqttConfig.java
@@ -5,12 +5,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.annotation.IntegrationComponentScan;
-import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.ExecutorChannel;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.mqtt.core.DefaultMqttPahoClientFactory;
 import org.springframework.integration.mqtt.core.MqttPahoClientFactory;
 import org.springframework.integration.mqtt.inbound.MqttPahoMessageDrivenChannelAdapter;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
 
 @Configuration
 @IntegrationComponentScan
@@ -31,9 +34,31 @@ public class MqttConfig {
     @Value("${spring.mqtt.default-topic}")
     private String defaultTopic;
 
+    @Value("${ingestion.executor.core-pool-size:4}")
+    private int executorCorePoolSize;
+
+    @Value("${ingestion.executor.max-pool-size:16}")
+    private int executorMaxPoolSize;
+
+    @Value("${ingestion.executor.queue-capacity:5000}")
+    private int executorQueueCapacity;
+
     @Bean
     public MessageChannel mqttInputChannel() {
-        return new DirectChannel();
+        return new ExecutorChannel(mqttIngestionExecutor());
+    }
+
+    @Bean
+    public Executor mqttIngestionExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setThreadNamePrefix("mqtt-ingest-");
+        executor.setCorePoolSize(executorCorePoolSize);
+        executor.setMaxPoolSize(Math.max(executorMaxPoolSize, executorCorePoolSize));
+        executor.setQueueCapacity(Math.max(executorQueueCapacity, 1));
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(10);
+        executor.initialize();
+        return executor;
     }
 
     @Bean
@@ -60,7 +85,7 @@ public class MqttConfig {
                 new MqttPahoMessageDrivenChannelAdapter(clientId, mqttClientFactory, defaultTopic);
         adapter.setCompletionTimeout(5_000);
         adapter.setQos(1);
-        adapter.setOutputChannel(mqttInputChannel());
+        adapter.setOutputChannelName("mqttInputChannel");
         return adapter;
     }
 }

--- a/src/main/java/com/iot/IoT/ingestion/consumer/MqttConsumer.java
+++ b/src/main/java/com/iot/IoT/ingestion/consumer/MqttConsumer.java
@@ -35,9 +35,11 @@ public class MqttConsumer {
 
     @ServiceActivator(inputChannel = "mqttInputChannel")
     public void handle(Message<?> message) {
+        long startedAtNanos = System.nanoTime();
         String topic = (String) message.getHeaders().get(MqttHeaders.RECEIVED_TOPIC);
         String rawPayload = payloadAsString(message.getPayload());
         ingestionMetricsCollector.recordMqttReceived();
+        ingestionMetricsCollector.incrementInFlight();
 
         try {
             DeviceStatusMessage statusMessage = mqttPayloadParser.parseDeviceStatus(rawPayload);
@@ -55,6 +57,12 @@ public class MqttConsumer {
                     topic,
                     rawPayload,
                     ex.getMessage());
+        } catch (RuntimeException ex) {
+            ingestionMetricsCollector.recordProcessingFailure();
+            log.error("[MQTT] Processing failed. topic={}, payload={}", topic, rawPayload, ex);
+        } finally {
+            ingestionMetricsCollector.decrementInFlight();
+            ingestionMetricsCollector.recordProcessingLatency(System.nanoTime() - startedAtNanos);
         }
     }
 

--- a/src/main/java/com/iot/IoT/ingestion/metrics/IngestionMetricsCollector.java
+++ b/src/main/java/com/iot/IoT/ingestion/metrics/IngestionMetricsCollector.java
@@ -1,13 +1,17 @@
 package com.iot.IoT.ingestion.metrics;
 
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 
@@ -25,6 +29,10 @@ public class IngestionMetricsCollector {
     private final LongAdder influxBypassTotal = new LongAdder();
     private final LongAdder redisSuccessTotal = new LongAdder();
     private final LongAdder redisFailureTotal = new LongAdder();
+    private final LongAdder processingFailureTotal = new LongAdder();
+    private final LongAdder overallPipelineSuccessTotal = new LongAdder();
+    private final LongAdder corePipelineSuccessTotal = new LongAdder();
+    private final AtomicInteger inFlight = new AtomicInteger(0);
 
     private final AtomicLong lastMqttReceived = new AtomicLong(0);
     private final AtomicLong lastParseSuccess = new AtomicLong(0);
@@ -34,6 +42,9 @@ public class IngestionMetricsCollector {
     private final AtomicLong lastInfluxBypass = new AtomicLong(0);
     private final AtomicLong lastRedisSuccess = new AtomicLong(0);
     private final AtomicLong lastRedisFailure = new AtomicLong(0);
+    private final AtomicLong lastProcessingFailure = new AtomicLong(0);
+    private final AtomicLong lastOverallPipelineSuccess = new AtomicLong(0);
+    private final AtomicLong lastCorePipelineSuccess = new AtomicLong(0);
 
     private final Counter mqttReceivedCounter;
     private final Counter parseSuccessCounter;
@@ -43,6 +54,10 @@ public class IngestionMetricsCollector {
     private final Counter influxBypassCounter;
     private final Counter redisSuccessCounter;
     private final Counter redisFailureCounter;
+    private final Counter processingFailureCounter;
+    private final Counter overallPipelineSuccessCounter;
+    private final Counter corePipelineSuccessCounter;
+    private final Timer processingLatencyTimer;
 
     public IngestionMetricsCollector(MeterRegistry meterRegistry) {
         this.mqttReceivedCounter = meterRegistry.counter("iot.ingestion.mqtt.received.total");
@@ -53,6 +68,13 @@ public class IngestionMetricsCollector {
         this.influxBypassCounter = meterRegistry.counter("iot.ingestion.influx.bypass.total");
         this.redisSuccessCounter = meterRegistry.counter("iot.ingestion.redis.success.total");
         this.redisFailureCounter = meterRegistry.counter("iot.ingestion.redis.failure.total");
+        this.processingFailureCounter = meterRegistry.counter("iot.ingestion.processing.failure.total");
+        this.overallPipelineSuccessCounter = meterRegistry.counter("iot.ingestion.pipeline.overall.success.total");
+        this.corePipelineSuccessCounter = meterRegistry.counter("iot.ingestion.pipeline.core.success.total");
+        this.processingLatencyTimer = meterRegistry.timer("iot.ingestion.processing.latency");
+        Gauge.builder("iot.ingestion.inflight", inFlight, AtomicInteger::get)
+                .description("Current number of in-flight ingestion tasks")
+                .register(meterRegistry);
     }
 
     public void recordMqttReceived() {
@@ -95,6 +117,35 @@ public class IngestionMetricsCollector {
         redisFailureCounter.increment();
     }
 
+    public void recordProcessingFailure() {
+        processingFailureTotal.increment();
+        processingFailureCounter.increment();
+    }
+
+    public void recordOverallPipelineSuccess() {
+        overallPipelineSuccessTotal.increment();
+        overallPipelineSuccessCounter.increment();
+    }
+
+    public void recordCorePipelineSuccess() {
+        corePipelineSuccessTotal.increment();
+        corePipelineSuccessCounter.increment();
+    }
+
+    public void incrementInFlight() {
+        inFlight.incrementAndGet();
+    }
+
+    public void decrementInFlight() {
+        inFlight.updateAndGet(current -> Math.max(current - 1, 0));
+    }
+
+    public void recordProcessingLatency(long nanos) {
+        if (nanos > 0) {
+            processingLatencyTimer.record(Duration.ofNanos(nanos));
+        }
+    }
+
     @Scheduled(fixedDelayString = "${ingestion.metrics-log-interval-ms:1000}")
     public void logSnapshot() {
         long mqttReceived = mqttReceivedTotal.sum();
@@ -105,6 +156,9 @@ public class IngestionMetricsCollector {
         long influxBypass = influxBypassTotal.sum();
         long redisSuccess = redisSuccessTotal.sum();
         long redisFailure = redisFailureTotal.sum();
+        long processingFailure = processingFailureTotal.sum();
+        long overallPipelineSuccess = overallPipelineSuccessTotal.sum();
+        long corePipelineSuccess = corePipelineSuccessTotal.sum();
 
         long mqttReceivedDelta = mqttReceived - lastMqttReceived.getAndSet(mqttReceived);
         long parseSuccessDelta = parseSuccess - lastParseSuccess.getAndSet(parseSuccess);
@@ -114,6 +168,11 @@ public class IngestionMetricsCollector {
         long influxBypassDelta = influxBypass - lastInfluxBypass.getAndSet(influxBypass);
         long redisSuccessDelta = redisSuccess - lastRedisSuccess.getAndSet(redisSuccess);
         long redisFailureDelta = redisFailure - lastRedisFailure.getAndSet(redisFailure);
+        long processingFailureDelta = processingFailure - lastProcessingFailure.getAndSet(processingFailure);
+        long overallPipelineSuccessDelta =
+                overallPipelineSuccess - lastOverallPipelineSuccess.getAndSet(overallPipelineSuccess);
+        long corePipelineSuccessDelta =
+                corePipelineSuccess - lastCorePipelineSuccess.getAndSet(corePipelineSuccess);
 
         if (mqttReceivedDelta == 0
                 && parseSuccessDelta == 0
@@ -122,11 +181,14 @@ public class IngestionMetricsCollector {
                 && influxFailureDelta == 0
                 && influxBypassDelta == 0
                 && redisSuccessDelta == 0
-                && redisFailureDelta == 0) {
+                && redisFailureDelta == 0
+                && processingFailureDelta == 0
+                && overallPipelineSuccessDelta == 0
+                && corePipelineSuccessDelta == 0) {
             return;
         }
 
-        log.info("[INGEST-METRICS/1s] recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, influxBypass={}, redisOk={}, redisFail={} | totals recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, influxBypass={}, redisOk={}, redisFail={}",
+        log.info("[INGEST-METRICS/1s] recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, influxBypass={}, redisOk={}, redisFail={}, procFail={}, overallOk={}, coreOk={}, inFlight={} | totals recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, influxBypass={}, redisOk={}, redisFail={}, procFail={}, overallOk={}, coreOk={}",
                 mqttReceivedDelta,
                 parseSuccessDelta,
                 parseFailureDelta,
@@ -135,6 +197,10 @@ public class IngestionMetricsCollector {
                 influxBypassDelta,
                 redisSuccessDelta,
                 redisFailureDelta,
+                processingFailureDelta,
+                overallPipelineSuccessDelta,
+                corePipelineSuccessDelta,
+                inFlight.get(),
                 mqttReceived,
                 parseSuccess,
                 parseFailure,
@@ -142,6 +208,9 @@ public class IngestionMetricsCollector {
                 influxFailure,
                 influxBypass,
                 redisSuccess,
-                redisFailure);
+                redisFailure,
+                processingFailure,
+                overallPipelineSuccess,
+                corePipelineSuccess);
     }
 }

--- a/src/main/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImpl.java
+++ b/src/main/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImpl.java
@@ -46,12 +46,15 @@ public class DeviceIngestionServiceImpl implements DeviceIngestionService {
     @Override
     public void ingest(DeviceStatusMessage message) {
         Instant now = Instant.now();
+        boolean influxWritten = false;
+        boolean redisUpdated = false;
 
         if (isInfluxWriteBypassMode()) {
             ingestionMetricsCollector.recordInfluxBypass();
         } else {
             try {
                 temperatureTimeSeriesPort.save(message, now);
+                influxWritten = true;
                 ingestionMetricsCollector.recordInfluxSuccess();
             } catch (Exception e) {
                 ingestionMetricsCollector.recordInfluxFailure();
@@ -66,20 +69,32 @@ public class DeviceIngestionServiceImpl implements DeviceIngestionService {
 
         try {
             heartbeatPort.updateLastSeen(message.deviceId(), now);
+            redisUpdated = true;
             ingestionMetricsCollector.recordRedisSuccess();
         } catch (Exception e) {
             ingestionMetricsCollector.recordRedisFailure();
             log.error("[INGESTION] Redis heartbeat update failed. deviceId={}", message.deviceId(), e);
         }
 
-        ControlAction action = controlDecisionEngine.decide(message);
-        log.info("[CONTROL] Decision made. deviceId={}, temp={}, targetTemp={}, state={}, action={}",
-                message.deviceId(),
-                message.temp(),
-                message.targetTemp(),
-                message.state(),
-                action);
-        deviceService.sendAutoControlCommand(message.deviceId(), action, now);
+        if (redisUpdated) {
+            ingestionMetricsCollector.recordCorePipelineSuccess();
+        }
+        if (redisUpdated && influxWritten) {
+            ingestionMetricsCollector.recordOverallPipelineSuccess();
+        }
+
+        try {
+            ControlAction action = controlDecisionEngine.decide(message);
+            log.info("[CONTROL] Decision made. deviceId={}, temp={}, targetTemp={}, state={}, action={}",
+                    message.deviceId(),
+                    message.temp(),
+                    message.targetTemp(),
+                    message.state(),
+                    action);
+            deviceService.sendAutoControlCommand(message.deviceId(), action, now);
+        } catch (RuntimeException ex) {
+            log.error("[CONTROL] Auto control dispatch failed. deviceId={}", message.deviceId(), ex);
+        }
     }
 
     private boolean isInfluxWriteBypassMode() {

--- a/src/test/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImplTest.java
+++ b/src/test/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImplTest.java
@@ -59,6 +59,8 @@ class DeviceIngestionServiceImplTest {
         verify(ingestionMetricsCollector, times(0)).recordInfluxFailure();
         verify(ingestionMetricsCollector, times(1)).recordRedisSuccess();
         verify(ingestionMetricsCollector, times(0)).recordRedisFailure();
+        verify(ingestionMetricsCollector, times(1)).recordCorePipelineSuccess();
+        verify(ingestionMetricsCollector, times(1)).recordOverallPipelineSuccess();
         verify(controlDecisionEngine, times(1)).decide(eq(message));
         verify(deviceService, times(1)).sendAutoControlCommand(eq("SV-001"), any(), any());
     }
@@ -77,6 +79,8 @@ class DeviceIngestionServiceImplTest {
         verify(ingestionMetricsCollector, times(1)).recordInfluxFailure();
         verify(ingestionMetricsCollector, times(1)).recordRedisSuccess();
         verify(ingestionMetricsCollector, times(0)).recordRedisFailure();
+        verify(ingestionMetricsCollector, times(1)).recordCorePipelineSuccess();
+        verify(ingestionMetricsCollector, never()).recordOverallPipelineSuccess();
         verify(controlDecisionEngine, times(1)).decide(eq(message));
         verify(deviceService, times(1)).sendAutoControlCommand(eq("SV-001"), any(), any());
     }
@@ -95,6 +99,8 @@ class DeviceIngestionServiceImplTest {
         verify(ingestionMetricsCollector, times(0)).recordInfluxFailure();
         verify(ingestionMetricsCollector, times(0)).recordRedisSuccess();
         verify(ingestionMetricsCollector, times(1)).recordRedisFailure();
+        verify(ingestionMetricsCollector, never()).recordCorePipelineSuccess();
+        verify(ingestionMetricsCollector, never()).recordOverallPipelineSuccess();
         verify(controlDecisionEngine, times(1)).decide(eq(message));
         verify(deviceService, times(1)).sendAutoControlCommand(eq("SV-001"), any(), any());
     }
@@ -114,6 +120,8 @@ class DeviceIngestionServiceImplTest {
         verify(ingestionMetricsCollector, never()).recordInfluxFailure();
         verify(ingestionMetricsCollector, times(1)).recordRedisSuccess();
         verify(ingestionMetricsCollector, never()).recordRedisFailure();
+        verify(ingestionMetricsCollector, times(1)).recordCorePipelineSuccess();
+        verify(ingestionMetricsCollector, never()).recordOverallPipelineSuccess();
         verify(controlDecisionEngine, times(1)).decide(eq(message));
         verify(deviceService, times(1)).sendAutoControlCommand(eq("SV-001"), any(), any());
     }
@@ -134,6 +142,8 @@ class DeviceIngestionServiceImplTest {
         verify(ingestionMetricsCollector, never()).recordInfluxFailure();
         verify(ingestionMetricsCollector, never()).recordRedisSuccess();
         verify(ingestionMetricsCollector, times(1)).recordRedisFailure();
+        verify(ingestionMetricsCollector, never()).recordCorePipelineSuccess();
+        verify(ingestionMetricsCollector, never()).recordOverallPipelineSuccess();
         verify(controlDecisionEngine, times(1)).decide(eq(message));
         verify(deviceService, times(1)).sendAutoControlCommand(eq("SV-001"), any(), any());
     }


### PR DESCRIPTION

  ## What Changed
  - MQTT inbound channel을 `DirectChannel`에서 executor-backed `ExecutorChannel`로 변경
  - broker 수신 스레드와 downstream ingestion 처리 경로를 느슨하게 분리
  - ingestion 처리 중 in-flight task, processing latency, processing failure 메트릭 추가
  - business success 관점 메트릭 추가
    - overall pipeline success
    - core pipeline success
  - control dispatch 예외가 ingestion 전체 실패로 번지지 않도록 예외 격리
  - observability / load-test / operations 문서 업데이트
  - ingestion service 테스트 보강

  ## Why
  - 기존 구조는 MQTT 수신과 downstream 저장/제어 처리가 사실상 동기적으로 연결되어 병목 해석이 어려웠음
  - connection-level success와 business-level success를 분리해서 봐야 실제 ingestion 안정성을 설명할 수 있음
  - 이번 변경으로 backend saturation을 더 명확히 관측하고, strict / bypass 비교 해석의 기반을 만들고자 했음

  ## How To Verify
  - 테스트 실행
  ```bash
  ./gradlew test

  - 런타임 확인
      - /actuator/prometheus에서 아래 메트릭 확인
          - iot_ingestion_processing_failure_total
          - iot_ingestion_pipeline_overall_success_total
          - iot_ingestion_pipeline_core_success_total
          - iot_ingestion_inflight
          - iot_ingestion_processing_latency_seconds

  ## Load Test Notes

  - local single-host WSL 환경에서 backend + simulator + Mosquitto + Redis + InfluxDB + MySQL를 함께 실행하는 조건에서는 CPU /
    memory / disk saturation이 빠르게 발생함
  - 특히 executor-backed ingestion 적용 후 입력이 더 빠르게 downstream으로 전달되면서 persistence path와 logging overhead 병목이
    더 명확하게 드러났음
  - 따라서 strict 고부하(2k~5k) 재검증은 local resource ceiling에 의해 재현성이 낮았고, 이번 PR에서는
      - ingestion isolation 구조 반영
      - business/core success 계측 추가
      - saturation 원인 식별
        까지를 핵심 결과로 정리함

  ## Risks / Limits

  - local WSL 환경에서는 strict 대용량 검증 재현성이 낮음
  - backpressure / queue decoupling / DLQ / replay는 아직 미구현
  - executor queue는 도입됐지만 downstream persistence bottleneck 자체를 제거한 것은 아님
  - MySQL / InfluxDB / logging I/O가 동시에 몰릴 때 single-host 환경 한계가 큼

  ## Next Step

  - queue-based decoupling 또는 backpressure 정책 도입
  - logging volume 축소 및 운영 로그 정책 분리
  - persistence path 분리 검토
  - strict / bypass 재검증은 더 안정적인 환경 또는 더 작은 단계적 부하로 수행
  closed #45 