### PR TITLE
refactor: strengthen message reliability and recovery policy

### DIFF
--- a/docs/adr/0001-ingestion-architecture.md
+++ b/docs/adr/0001-ingestion-architecture.md
@@ -26,3 +26,15 @@ Accepted
 - 실패 메시지 전용 채널/재처리 정책 도입
 - QoS/재전송 정책 및 idempotency 키 설계
 - 10k 시뮬레이터 기반 부하 테스트 시나리오 정교화
+
+## Reliability Policy Addendum (Phase 3)
+- uplink duplicate suppression은 `deviceId + rawPayload` 기준의 short-window best-effort 정책으로 처리한다.
+  - 목적: broker/network 재전송으로 인한 즉시 중복 유입 억제
+  - 한계: semantic dedup이 아니라 transport-level suppression에 가깝다.
+- failure classification:
+  - parse invalid / validation failed: non-replayable, dead-letter 대상
+  - Influx/Redis storage failure: replay candidate
+  - control dispatch failure: replay candidate
+- replay policy:
+  - parse invalid payload는 자동 재처리하지 않는다.
+  - storage/control failure는 replayable failure로 계수하고 후속 retry/DLQ 체계의 입력으로 사용한다.

--- a/docs/load-test-scenarios.md
+++ b/docs/load-test-scenarios.md
@@ -149,6 +149,10 @@ Interpretation note:
 Definition notes:
 - DLQ-ready: parse/storage failures can be separated and counted independently.
 - Idempotency policy: `deviceId + timestamp(or sequence)` key strategy documented and testable.
+- Current Phase 3 local policy:
+  - best-effort duplicate suppression uses `deviceId + rawPayload` within a short time window
+  - parse invalid payloads are classified as non-replayable dead-letter candidates
+  - storage/control failures are classified as replay candidates
 
 ## Performance Methodology
 - Separate metrics into:
@@ -168,6 +172,12 @@ Definition notes:
   - failure signature
   - service behavior (degrade/recover)
   - MTTR measurement
+
+## Phase 3 Reliability Metrics
+- `iot_ingestion_duplicate_dropped_total`
+- `iot_ingestion_parse_dead_letter_total`
+- `iot_ingestion_storage_replay_candidate_total`
+- `iot_ingestion_control_replay_candidate_total`
 
 ## Security and Financial-Grade Readiness
 - Add and track minimum controls:

--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -22,6 +22,9 @@
 - `influx failure ratio` 상승 시 Influx 연결/토큰/지연 점검
 - `redis failure ratio` 상승 시 Redis 연결/메모리 점검
 - `processing failure ratio` 상승 시 애플리케이션 내부 예외 또는 executor backlog 의심
+- `parse dead-letter` 증가 시 non-replayable payload 오류로 분류
+- `storage replay candidate` 증가 시 Influx/Redis 복구 후 재처리 후보 증가로 해석
+- `control replay candidate` 증가 시 downlink publish/ACK 경로 점검 우선
 
 3. Ingestion Pipeline Success 확인
 - `overall pipeline success`가 하락하면 Influx 또는 Redis 경로를 우선 의심
@@ -46,6 +49,7 @@
   - 배포 직후 발생인지 확인
 - 조치:
   - 파서 유효성 규칙과 송신 포맷 동기화
+  - `parse dead-letter`를 non-replayable failure로 분류하고 자동 재처리는 수행하지 않음
 
 ### 2) Downlink Timeout 급증
 - 증상: `timeout ratio` 상승, `acked ratio` 하락
@@ -76,11 +80,22 @@
   - 우선 bypass 모드로 core path를 분리 검증
   - Influx 연결/토큰/스토리지 상태 복구 후 strict 재검증
 
+### 5) Replay Candidate 증가
+- 증상: `storage replay candidate` 또는 `control replay candidate` 증가
+- 점검:
+  - Influx/Redis/broker 상태
+  - 최근 deploy 이후 예외 패턴 변화
+  - duplicate suppression 증가 여부와 동반되는지 확인
+- 조치:
+  - parse invalid는 재처리하지 않음
+  - storage/control failure는 복구 후 재처리 대상 후보로 별도 취급
+
 ## Suggested Thresholds (Initial)
 - parse failure ratio: `> 0.01` (1%)
 - timeout ratio: `> 0.05` (5%)
 - downlink failed/s: 평시 대비 3배 이상
 - inflight: 지속 증가 추세면 backlog 의심
+- duplicate dropped/s: 평시 대비 급증 시 broker/network duplicate 여부 확인
 
 ## Related Docs
 - `docs/observability.md`

--- a/docs/refactoring-roadmap.md
+++ b/docs/refactoring-roadmap.md
@@ -67,6 +67,16 @@
   - executor pool/queue 튜닝 근거 수치화
   - backlog 발생 시 후속 큐 분리 전략(DLQ/replay 포함) 결정
 
+## Phase 3 Update
+- 현재 구현 상태:
+  - best-effort uplink duplicate suppression 추가
+  - parse invalid / storage failure / control dispatch failure를 서로 다른 reliability class로 분류
+  - dead-letter candidate와 replay candidate를 메트릭/로그로 구분
+- 남은 보강:
+  - persistent DLQ 도입
+  - replay 실행 경로 구현
+  - duplicate suppression을 timestamp/sequence 기반 정책으로 고도화
+
 ## 5. Phase Details
 ## Phase 1: Device Management API
 - 목표:

--- a/src/main/java/com/iot/IoT/ingestion/consumer/MqttConsumer.java
+++ b/src/main/java/com/iot/IoT/ingestion/consumer/MqttConsumer.java
@@ -13,6 +13,10 @@ import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Component
 public class MqttConsumer {
@@ -22,15 +26,20 @@ public class MqttConsumer {
     private final MqttPayloadParser mqttPayloadParser;
     private final DeviceIngestionService deviceIngestionService;
     private final IngestionMetricsCollector ingestionMetricsCollector;
+    private final Duration duplicateSuppressWindow;
+    private final Map<String, Instant> recentPayloads = new ConcurrentHashMap<>();
 
     public MqttConsumer(
             MqttPayloadParser mqttPayloadParser,
             DeviceIngestionService deviceIngestionService,
-            IngestionMetricsCollector ingestionMetricsCollector
+            IngestionMetricsCollector ingestionMetricsCollector,
+            @org.springframework.beans.factory.annotation.Value("${ingestion.duplicate-suppress-window-seconds:2}")
+            long duplicateSuppressWindowSeconds
     ) {
         this.mqttPayloadParser = mqttPayloadParser;
         this.deviceIngestionService = deviceIngestionService;
         this.ingestionMetricsCollector = ingestionMetricsCollector;
+        this.duplicateSuppressWindow = Duration.ofSeconds(Math.max(duplicateSuppressWindowSeconds, 1));
     }
 
     @ServiceActivator(inputChannel = "mqttInputChannel")
@@ -43,6 +52,14 @@ public class MqttConsumer {
 
         try {
             DeviceStatusMessage statusMessage = mqttPayloadParser.parseDeviceStatus(rawPayload);
+            if (isSuppressedDuplicate(statusMessage, rawPayload)) {
+                ingestionMetricsCollector.recordDuplicateDropped();
+                log.warn("[RELIABILITY] Duplicate telemetry suppressed. topic={}, deviceId={}, windowSeconds={}",
+                        topic,
+                        statusMessage.deviceId(),
+                        duplicateSuppressWindow.toSeconds());
+                return;
+            }
             ingestionMetricsCollector.recordParseSuccess();
             log.info("[MQTT] Parsed device status. topic={}, deviceId={}, temp={}, targetTemp={}, state={}",
                     topic,
@@ -53,17 +70,34 @@ public class MqttConsumer {
             deviceIngestionService.ingest(statusMessage);
         } catch (InvalidMqttPayloadException ex) {
             ingestionMetricsCollector.recordParseFailure();
+            ingestionMetricsCollector.recordParseDeadLetter();
             log.warn("[MQTT] Invalid payload. topic={}, payload={}, reason={}",
                     topic,
                     rawPayload,
                     ex.getMessage());
+            log.warn("[RELIABILITY] Parse failure classified. topic={}, failureType={}, replayable={}",
+                    topic,
+                    ex.failureType(),
+                    ex.failureType().replayable());
         } catch (RuntimeException ex) {
             ingestionMetricsCollector.recordProcessingFailure();
+            ingestionMetricsCollector.recordStorageReplayCandidate();
             log.error("[MQTT] Processing failed. topic={}, payload={}", topic, rawPayload, ex);
+            log.error("[RELIABILITY] Runtime processing failure classified. topic={}, replayable=true", topic, ex);
         } finally {
             ingestionMetricsCollector.decrementInFlight();
             ingestionMetricsCollector.recordProcessingLatency(System.nanoTime() - startedAtNanos);
         }
+    }
+
+    private boolean isSuppressedDuplicate(DeviceStatusMessage message, String rawPayload) {
+        Instant now = Instant.now();
+        Instant threshold = now.minus(duplicateSuppressWindow);
+        recentPayloads.entrySet().removeIf(entry -> entry.getValue().isBefore(threshold));
+
+        String dedupKey = message.deviceId() + ":" + rawPayload;
+        Instant previous = recentPayloads.put(dedupKey, now);
+        return previous != null && !previous.isBefore(threshold);
     }
 
     private String payloadAsString(Object payload) {

--- a/src/main/java/com/iot/IoT/ingestion/exception/InvalidMqttPayloadException.java
+++ b/src/main/java/com/iot/IoT/ingestion/exception/InvalidMqttPayloadException.java
@@ -2,11 +2,35 @@ package com.iot.IoT.ingestion.exception;
 
 public class InvalidMqttPayloadException extends RuntimeException {
 
-    public InvalidMqttPayloadException(String message) {
+    private final FailureType failureType;
+
+    public InvalidMqttPayloadException(String message, FailureType failureType) {
         super(message);
+        this.failureType = failureType;
     }
 
-    public InvalidMqttPayloadException(String message, Throwable cause) {
+    public InvalidMqttPayloadException(String message, Throwable cause, FailureType failureType) {
         super(message, cause);
+        this.failureType = failureType;
+    }
+
+    public FailureType failureType() {
+        return failureType;
+    }
+
+    public enum FailureType {
+        INVALID_JSON(false),
+        VALIDATION_FAILED(false),
+        DUPLICATE_SUPPRESSED(false);
+
+        private final boolean replayable;
+
+        FailureType(boolean replayable) {
+            this.replayable = replayable;
+        }
+
+        public boolean replayable() {
+            return replayable;
+        }
     }
 }

--- a/src/main/java/com/iot/IoT/ingestion/metrics/IngestionMetricsCollector.java
+++ b/src/main/java/com/iot/IoT/ingestion/metrics/IngestionMetricsCollector.java
@@ -32,6 +32,10 @@ public class IngestionMetricsCollector {
     private final LongAdder processingFailureTotal = new LongAdder();
     private final LongAdder overallPipelineSuccessTotal = new LongAdder();
     private final LongAdder corePipelineSuccessTotal = new LongAdder();
+    private final LongAdder duplicateDroppedTotal = new LongAdder();
+    private final LongAdder parseDeadLetterTotal = new LongAdder();
+    private final LongAdder storageReplayCandidateTotal = new LongAdder();
+    private final LongAdder controlReplayCandidateTotal = new LongAdder();
     private final AtomicInteger inFlight = new AtomicInteger(0);
 
     private final AtomicLong lastMqttReceived = new AtomicLong(0);
@@ -45,6 +49,10 @@ public class IngestionMetricsCollector {
     private final AtomicLong lastProcessingFailure = new AtomicLong(0);
     private final AtomicLong lastOverallPipelineSuccess = new AtomicLong(0);
     private final AtomicLong lastCorePipelineSuccess = new AtomicLong(0);
+    private final AtomicLong lastDuplicateDropped = new AtomicLong(0);
+    private final AtomicLong lastParseDeadLetter = new AtomicLong(0);
+    private final AtomicLong lastStorageReplayCandidate = new AtomicLong(0);
+    private final AtomicLong lastControlReplayCandidate = new AtomicLong(0);
 
     private final Counter mqttReceivedCounter;
     private final Counter parseSuccessCounter;
@@ -57,6 +65,10 @@ public class IngestionMetricsCollector {
     private final Counter processingFailureCounter;
     private final Counter overallPipelineSuccessCounter;
     private final Counter corePipelineSuccessCounter;
+    private final Counter duplicateDroppedCounter;
+    private final Counter parseDeadLetterCounter;
+    private final Counter storageReplayCandidateCounter;
+    private final Counter controlReplayCandidateCounter;
     private final Timer processingLatencyTimer;
 
     public IngestionMetricsCollector(MeterRegistry meterRegistry) {
@@ -71,6 +83,10 @@ public class IngestionMetricsCollector {
         this.processingFailureCounter = meterRegistry.counter("iot.ingestion.processing.failure.total");
         this.overallPipelineSuccessCounter = meterRegistry.counter("iot.ingestion.pipeline.overall.success.total");
         this.corePipelineSuccessCounter = meterRegistry.counter("iot.ingestion.pipeline.core.success.total");
+        this.duplicateDroppedCounter = meterRegistry.counter("iot.ingestion.duplicate.dropped.total");
+        this.parseDeadLetterCounter = meterRegistry.counter("iot.ingestion.parse.dead_letter.total");
+        this.storageReplayCandidateCounter = meterRegistry.counter("iot.ingestion.storage.replay_candidate.total");
+        this.controlReplayCandidateCounter = meterRegistry.counter("iot.ingestion.control.replay_candidate.total");
         this.processingLatencyTimer = meterRegistry.timer("iot.ingestion.processing.latency");
         Gauge.builder("iot.ingestion.inflight", inFlight, AtomicInteger::get)
                 .description("Current number of in-flight ingestion tasks")
@@ -132,6 +148,26 @@ public class IngestionMetricsCollector {
         corePipelineSuccessCounter.increment();
     }
 
+    public void recordDuplicateDropped() {
+        duplicateDroppedTotal.increment();
+        duplicateDroppedCounter.increment();
+    }
+
+    public void recordParseDeadLetter() {
+        parseDeadLetterTotal.increment();
+        parseDeadLetterCounter.increment();
+    }
+
+    public void recordStorageReplayCandidate() {
+        storageReplayCandidateTotal.increment();
+        storageReplayCandidateCounter.increment();
+    }
+
+    public void recordControlReplayCandidate() {
+        controlReplayCandidateTotal.increment();
+        controlReplayCandidateCounter.increment();
+    }
+
     public void incrementInFlight() {
         inFlight.incrementAndGet();
     }
@@ -159,6 +195,10 @@ public class IngestionMetricsCollector {
         long processingFailure = processingFailureTotal.sum();
         long overallPipelineSuccess = overallPipelineSuccessTotal.sum();
         long corePipelineSuccess = corePipelineSuccessTotal.sum();
+        long duplicateDropped = duplicateDroppedTotal.sum();
+        long parseDeadLetter = parseDeadLetterTotal.sum();
+        long storageReplayCandidate = storageReplayCandidateTotal.sum();
+        long controlReplayCandidate = controlReplayCandidateTotal.sum();
 
         long mqttReceivedDelta = mqttReceived - lastMqttReceived.getAndSet(mqttReceived);
         long parseSuccessDelta = parseSuccess - lastParseSuccess.getAndSet(parseSuccess);
@@ -173,6 +213,12 @@ public class IngestionMetricsCollector {
                 overallPipelineSuccess - lastOverallPipelineSuccess.getAndSet(overallPipelineSuccess);
         long corePipelineSuccessDelta =
                 corePipelineSuccess - lastCorePipelineSuccess.getAndSet(corePipelineSuccess);
+        long duplicateDroppedDelta = duplicateDropped - lastDuplicateDropped.getAndSet(duplicateDropped);
+        long parseDeadLetterDelta = parseDeadLetter - lastParseDeadLetter.getAndSet(parseDeadLetter);
+        long storageReplayCandidateDelta =
+                storageReplayCandidate - lastStorageReplayCandidate.getAndSet(storageReplayCandidate);
+        long controlReplayCandidateDelta =
+                controlReplayCandidate - lastControlReplayCandidate.getAndSet(controlReplayCandidate);
 
         if (mqttReceivedDelta == 0
                 && parseSuccessDelta == 0
@@ -184,11 +230,15 @@ public class IngestionMetricsCollector {
                 && redisFailureDelta == 0
                 && processingFailureDelta == 0
                 && overallPipelineSuccessDelta == 0
-                && corePipelineSuccessDelta == 0) {
+                && corePipelineSuccessDelta == 0
+                && duplicateDroppedDelta == 0
+                && parseDeadLetterDelta == 0
+                && storageReplayCandidateDelta == 0
+                && controlReplayCandidateDelta == 0) {
             return;
         }
 
-        log.info("[INGEST-METRICS/1s] recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, influxBypass={}, redisOk={}, redisFail={}, procFail={}, overallOk={}, coreOk={}, inFlight={} | totals recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, influxBypass={}, redisOk={}, redisFail={}, procFail={}, overallOk={}, coreOk={}",
+        log.info("[INGEST-METRICS/1s] recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, influxBypass={}, redisOk={}, redisFail={}, procFail={}, overallOk={}, coreOk={}, dupDrop={}, parseDlq={}, storageReplay={}, controlReplay={}, inFlight={} | totals recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, influxBypass={}, redisOk={}, redisFail={}, procFail={}, overallOk={}, coreOk={}, dupDrop={}, parseDlq={}, storageReplay={}, controlReplay={}",
                 mqttReceivedDelta,
                 parseSuccessDelta,
                 parseFailureDelta,
@@ -200,6 +250,10 @@ public class IngestionMetricsCollector {
                 processingFailureDelta,
                 overallPipelineSuccessDelta,
                 corePipelineSuccessDelta,
+                duplicateDroppedDelta,
+                parseDeadLetterDelta,
+                storageReplayCandidateDelta,
+                controlReplayCandidateDelta,
                 inFlight.get(),
                 mqttReceived,
                 parseSuccess,
@@ -211,6 +265,10 @@ public class IngestionMetricsCollector {
                 redisFailure,
                 processingFailure,
                 overallPipelineSuccess,
-                corePipelineSuccess);
+                corePipelineSuccess,
+                duplicateDropped,
+                parseDeadLetter,
+                storageReplayCandidate,
+                controlReplayCandidate);
     }
 }

--- a/src/main/java/com/iot/IoT/ingestion/parser/MqttPayloadParser.java
+++ b/src/main/java/com/iot/IoT/ingestion/parser/MqttPayloadParser.java
@@ -30,7 +30,11 @@ public class MqttPayloadParser {
             validate(message);
             return message;
         } catch (JsonProcessingException e) {
-            throw new InvalidMqttPayloadException("MQTT payload is not valid JSON for DeviceStatusMessage", e);
+            throw new InvalidMqttPayloadException(
+                    "MQTT payload is not valid JSON for DeviceStatusMessage",
+                    e,
+                    InvalidMqttPayloadException.FailureType.INVALID_JSON
+            );
         }
     }
 
@@ -40,7 +44,10 @@ public class MqttPayloadParser {
             String details = violations.stream()
                     .map(v -> v.getPropertyPath() + " " + v.getMessage())
                     .collect(Collectors.joining(", "));
-            throw new InvalidMqttPayloadException("MQTT payload validation failed: " + details);
+            throw new InvalidMqttPayloadException(
+                    "MQTT payload validation failed: " + details,
+                    InvalidMqttPayloadException.FailureType.VALIDATION_FAILED
+            );
         }
     }
 }

--- a/src/main/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImpl.java
+++ b/src/main/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImpl.java
@@ -58,12 +58,15 @@ public class DeviceIngestionServiceImpl implements DeviceIngestionService {
                 ingestionMetricsCollector.recordInfluxSuccess();
             } catch (Exception e) {
                 ingestionMetricsCollector.recordInfluxFailure();
+                ingestionMetricsCollector.recordStorageReplayCandidate();
                 log.error("[INGESTION] Influx write failed. deviceId={}, temp={}, targetTemp={}, state={}",
                         message.deviceId(),
                         message.temp(),
                         message.targetTemp(),
                         message.state(),
                         e);
+                log.error("[RELIABILITY] Storage failure classified. store=INFLUX, deviceId={}, replayable=true",
+                        message.deviceId(), e);
             }
         }
 
@@ -73,7 +76,10 @@ public class DeviceIngestionServiceImpl implements DeviceIngestionService {
             ingestionMetricsCollector.recordRedisSuccess();
         } catch (Exception e) {
             ingestionMetricsCollector.recordRedisFailure();
+            ingestionMetricsCollector.recordStorageReplayCandidate();
             log.error("[INGESTION] Redis heartbeat update failed. deviceId={}", message.deviceId(), e);
+            log.error("[RELIABILITY] Storage failure classified. store=REDIS, deviceId={}, replayable=true",
+                    message.deviceId(), e);
         }
 
         if (redisUpdated) {
@@ -93,7 +99,10 @@ public class DeviceIngestionServiceImpl implements DeviceIngestionService {
                     action);
             deviceService.sendAutoControlCommand(message.deviceId(), action, now);
         } catch (RuntimeException ex) {
+            ingestionMetricsCollector.recordControlReplayCandidate();
             log.error("[CONTROL] Auto control dispatch failed. deviceId={}", message.deviceId(), ex);
+            log.error("[RELIABILITY] Control dispatch failure classified. deviceId={}, replayable=true",
+                    message.deviceId(), ex);
         }
     }
 

--- a/src/test/java/com/iot/IoT/ingestion/parser/MqttPayloadParserTest.java
+++ b/src/test/java/com/iot/IoT/ingestion/parser/MqttPayloadParserTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MqttPayloadParserTest {
@@ -44,7 +45,11 @@ class MqttPayloadParserTest {
     void parseDeviceStatus_missingField() {
         String payload = "{\"deviceId\":\"SV-001\",\"temp\":65.5,\"state\":\"HEATING\"}";
 
-        assertThrows(InvalidMqttPayloadException.class, () -> parser.parseDeviceStatus(payload));
+        InvalidMqttPayloadException exception =
+                assertThrows(InvalidMqttPayloadException.class, () -> parser.parseDeviceStatus(payload));
+
+        assertEquals(InvalidMqttPayloadException.FailureType.VALIDATION_FAILED, exception.failureType());
+        assertFalse(exception.failureType().replayable());
     }
 
     @Test
@@ -52,7 +57,11 @@ class MqttPayloadParserTest {
     void parseDeviceStatus_unknownEnum() {
         String payload = "{\"deviceId\":\"SV-001\",\"temp\":65.5,\"targetTemp\":70.0,\"state\":\"RUNNING\"}";
 
-        assertThrows(InvalidMqttPayloadException.class, () -> parser.parseDeviceStatus(payload));
+        InvalidMqttPayloadException exception =
+                assertThrows(InvalidMqttPayloadException.class, () -> parser.parseDeviceStatus(payload));
+
+        assertEquals(InvalidMqttPayloadException.FailureType.INVALID_JSON, exception.failureType());
+        assertFalse(exception.failureType().replayable());
     }
 
     @Test
@@ -60,7 +69,11 @@ class MqttPayloadParserTest {
     void parseDeviceStatus_invalidNumberType() {
         String payload = "{\"deviceId\":\"SV-001\",\"temp\":\"hot\",\"targetTemp\":70.0,\"state\":\"HEATING\"}";
 
-        assertThrows(InvalidMqttPayloadException.class, () -> parser.parseDeviceStatus(payload));
+        InvalidMqttPayloadException exception =
+                assertThrows(InvalidMqttPayloadException.class, () -> parser.parseDeviceStatus(payload));
+
+        assertEquals(InvalidMqttPayloadException.FailureType.INVALID_JSON, exception.failureType());
+        assertFalse(exception.failureType().replayable());
     }
 
     @Test
@@ -68,6 +81,10 @@ class MqttPayloadParserTest {
     void parseDeviceStatus_unknownField() {
         String payload = "{\"deviceId\":\"SV-001\",\"temp\":65.5,\"targetTemp\":70.0,\"state\":\"HEATING\",\"foo\":\"bar\"}";
 
-        assertThrows(InvalidMqttPayloadException.class, () -> parser.parseDeviceStatus(payload));
+        InvalidMqttPayloadException exception =
+                assertThrows(InvalidMqttPayloadException.class, () -> parser.parseDeviceStatus(payload));
+
+        assertEquals(InvalidMqttPayloadException.FailureType.INVALID_JSON, exception.failureType());
+        assertFalse(exception.failureType().replayable());
     }
 }

--- a/src/test/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImplTest.java
+++ b/src/test/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImplTest.java
@@ -77,6 +77,7 @@ class DeviceIngestionServiceImplTest {
         verify(heartbeatPort, times(1)).updateLastSeen(eq("SV-001"), any());
         verify(ingestionMetricsCollector, times(0)).recordInfluxSuccess();
         verify(ingestionMetricsCollector, times(1)).recordInfluxFailure();
+        verify(ingestionMetricsCollector, times(1)).recordStorageReplayCandidate();
         verify(ingestionMetricsCollector, times(1)).recordRedisSuccess();
         verify(ingestionMetricsCollector, times(0)).recordRedisFailure();
         verify(ingestionMetricsCollector, times(1)).recordCorePipelineSuccess();
@@ -99,6 +100,7 @@ class DeviceIngestionServiceImplTest {
         verify(ingestionMetricsCollector, times(0)).recordInfluxFailure();
         verify(ingestionMetricsCollector, times(0)).recordRedisSuccess();
         verify(ingestionMetricsCollector, times(1)).recordRedisFailure();
+        verify(ingestionMetricsCollector, times(1)).recordStorageReplayCandidate();
         verify(ingestionMetricsCollector, never()).recordCorePipelineSuccess();
         verify(ingestionMetricsCollector, never()).recordOverallPipelineSuccess();
         verify(controlDecisionEngine, times(1)).decide(eq(message));
@@ -146,6 +148,21 @@ class DeviceIngestionServiceImplTest {
         verify(ingestionMetricsCollector, never()).recordOverallPipelineSuccess();
         verify(controlDecisionEngine, times(1)).decide(eq(message));
         verify(deviceService, times(1)).sendAutoControlCommand(eq("SV-001"), any(), any());
+    }
+
+    @Test
+    @DisplayName("Should classify control dispatch failure as replay candidate")
+    void ingest_controlDispatchFails_replayCandidate() {
+        DeviceStatusMessage message = sampleMessage();
+        doThrow(new RuntimeException("publish down")).when(deviceService).sendAutoControlCommand(eq("SV-001"), any(), any());
+
+        service.ingest(message);
+
+        verify(ingestionMetricsCollector, times(1)).recordInfluxSuccess();
+        verify(ingestionMetricsCollector, times(1)).recordRedisSuccess();
+        verify(ingestionMetricsCollector, times(1)).recordCorePipelineSuccess();
+        verify(ingestionMetricsCollector, times(1)).recordOverallPipelineSuccess();
+        verify(ingestionMetricsCollector, times(1)).recordControlReplayCandidate();
     }
 
     private DeviceStatusMessage sampleMessage() {


### PR DESCRIPTION
 ## What Changed
  - MQTT payload parse failure를 `INVALID_JSON`, `VALIDATION_FAILED`로 분류하도록 확장
  - duplicate telemetry에 대한 best-effort suppression 정책 추가
    - `deviceId + raw payload`
    - 짧은 suppression window 기반 중복 억제
  - ingestion reliability 메트릭 추가
    - duplicate dropped
    - parse dead-letter
    - storage replay candidate
    - control replay candidate
  - Influx / Redis 저장 실패를 replay candidate로 분류
  - auto control dispatch 실패를 replay candidate로 분류
  - parser / ingestion service 테스트 보강
  - reliability 정책을 ADR / runbook / load-test scenario / roadmap 문서에 반영

  ## Why
  - 기존 구조는 parse failure와 runtime/storage/control failure를 세분화해 설명하기 어려웠음
  - 면접 및 포트폴리오 관점에서 유실 / 중복 / 실패 / 재처리 기준을 코드와 문서 양쪽에서 명확히 할 필요가 있었음
  - 이번 PR은 실제 DLQ/worker 도입 전 단계로, 최소한의 failure classification과 recovery policy를 정리하는 데 목적이 있음

  ## How To Verify
  - 테스트 실행
  ./gradlew test

  - 확인 포인트
      - invalid JSON / validation failure가 서로 다른 failure type으로 분류되는지
      - duplicate telemetry가 suppression window 내에서 억제되는지
      - Influx / Redis 실패 시 replay candidate 메트릭이 증가하는지
      - auto control dispatch 실패 시 control replay candidate가 기록되는지

  ## Risks / Limits

  - duplicate suppression은 best-effort in-memory 정책이며, 프로세스 재시작 시 상태가 유지되지 않음
  - 실제 DLQ 저장소나 replay worker는 아직 없음
  - replay candidate 분류는 도입했지만 자동 재처리 흐름까지 구현된 것은 아님
  - multi-instance 환경에서 deduplication을 강하게 보장하지는 않음

  ## Next Step

  - failure event를 실제 적재할 DLQ 또는 persistence-backed failure store 도입
  - replay worker / operator-triggered replay flow 구현
  - broker restart / Redis down / Influx latency spike에 대한 chaos 시나리오 검증 강화
  - multi-instance 환경 기준 dedup / idempotency 전략 구체화
 closed #47 