### PR TITLE
 refactor: split device service by use case

### DIFF
--- a/docs/refactoring-roadmap.md
+++ b/docs/refactoring-roadmap.md
@@ -77,6 +77,16 @@
   - replay 실행 경로 구현
   - duplicate suppression을 timestamp/sequence 기반 정책으로 고도화
 
+## Phase 4 Update
+- 현재 구현 상태:
+  - `DeviceServiceImpl`를 얇은 façade로 축소
+  - query / control policy / command / reliability 책임을 전용 서비스로 분리
+  - reliability scheduler가 전용 reliability service에 직접 의존하도록 정리
+- 남은 보강:
+  - controller가 필요 시 유스케이스 서비스에 직접 의존하도록 추가 축소 검토
+  - 전용 서비스별 테스트 파일 분리
+  - 공통 매핑/정규화 로직의 지원 클래스로의 승격 여부 검토
+
 ## 5. Phase Details
 ## Phase 1: Device Management API
 - 목표:

--- a/src/main/java/com/iot/IoT/service/DeviceCommandReliabilityScheduler.java
+++ b/src/main/java/com/iot/IoT/service/DeviceCommandReliabilityScheduler.java
@@ -6,14 +6,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class DeviceCommandReliabilityScheduler {
 
-    private final DeviceService deviceService;
+    private final DeviceCommandReliabilityService deviceCommandReliabilityService;
 
-    public DeviceCommandReliabilityScheduler(DeviceService deviceService) {
-        this.deviceService = deviceService;
+    public DeviceCommandReliabilityScheduler(DeviceCommandReliabilityService deviceCommandReliabilityService) {
+        this.deviceCommandReliabilityService = deviceCommandReliabilityService;
     }
 
     @Scheduled(fixedDelayString = "${downlink.reliability.scan-interval-ms:5000}")
     public void scanAndProcess() {
-        deviceService.processCommandReliability();
+        deviceCommandReliabilityService.processCommandReliability();
     }
 }

--- a/src/main/java/com/iot/IoT/service/DeviceCommandReliabilityService.java
+++ b/src/main/java/com/iot/IoT/service/DeviceCommandReliabilityService.java
@@ -1,0 +1,97 @@
+package com.iot.IoT.service;
+
+import com.iot.IoT.entity.DeviceCommand;
+import com.iot.IoT.entity.DeviceCommandStatus;
+import com.iot.IoT.mqtt.port.DeviceCommandPublisherPort;
+import com.iot.IoT.repository.DeviceCommandRepository;
+import com.iot.IoT.service.metrics.DownlinkMetricsRecorder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.EnumSet;
+import java.util.List;
+
+@Service
+public class DeviceCommandReliabilityService {
+
+    private static final EnumSet<DeviceCommandStatus> RELIABILITY_TARGET_STATUSES =
+            EnumSet.of(DeviceCommandStatus.SENT, DeviceCommandStatus.PENDING);
+
+    private final DeviceCommandRepository deviceCommandRepository;
+    private final DeviceCommandPublisherPort deviceCommandPublisherPort;
+    private final DownlinkMetricsRecorder downlinkMetricsRecorder;
+    private final Duration commandRetryInterval;
+
+    public DeviceCommandReliabilityService(
+            DeviceCommandRepository deviceCommandRepository,
+            DeviceCommandPublisherPort deviceCommandPublisherPort,
+            DownlinkMetricsRecorder downlinkMetricsRecorder,
+            @Value("${downlink.retry-interval-seconds:10}") long commandRetryIntervalSeconds
+    ) {
+        this.deviceCommandRepository = deviceCommandRepository;
+        this.deviceCommandPublisherPort = deviceCommandPublisherPort;
+        this.downlinkMetricsRecorder = downlinkMetricsRecorder;
+        this.commandRetryInterval = Duration.ofSeconds(commandRetryIntervalSeconds);
+    }
+
+    @Transactional
+    public void processCommandReliability() {
+        Instant now = Instant.now();
+        List<DeviceCommand> targets = deviceCommandRepository.findByStatusIn(RELIABILITY_TARGET_STATUSES);
+        for (DeviceCommand command : targets) {
+            if (command.getStatus() == DeviceCommandStatus.ACKED
+                    || command.getStatus() == DeviceCommandStatus.EXPIRED
+                    || command.getStatus() == DeviceCommandStatus.FAILED) {
+                continue;
+            }
+            if (command.getExpireAt() != null && now.isAfter(command.getExpireAt())) {
+                command.setStatus(DeviceCommandStatus.EXPIRED);
+                command.setNextRetryAt(null);
+                command.setErrorMessage("ack timeout expired");
+                deviceCommandRepository.save(command);
+                downlinkMetricsRecorder.recordExpired();
+                continue;
+            }
+            if (command.getStatus() == DeviceCommandStatus.PENDING) {
+                retryPublish(command, now);
+                continue;
+            }
+            if (command.getStatus() == DeviceCommandStatus.SENT
+                    && command.getNextRetryAt() != null
+                    && !now.isBefore(command.getNextRetryAt())
+                    && command.getRetryCount() < command.getMaxRetries()) {
+                retryPublish(command, now);
+            }
+        }
+    }
+
+    private void retryPublish(DeviceCommand command, Instant now) {
+        try {
+            deviceCommandPublisherPort.publish(command.getTopic(), command.getPayload());
+            command.setStatus(DeviceCommandStatus.SENT);
+            command.setSentAt(now);
+            command.setRetryCount(command.getRetryCount() + 1);
+            command.setNextRetryAt(now.plus(commandRetryInterval));
+            command.setErrorMessage(null);
+            downlinkMetricsRecorder.recordRetried();
+            downlinkMetricsRecorder.recordSent();
+        } catch (RuntimeException ex) {
+            int nextRetry = command.getRetryCount() + 1;
+            command.setRetryCount(nextRetry);
+            if (nextRetry >= command.getMaxRetries()) {
+                command.setStatus(DeviceCommandStatus.FAILED);
+                command.setNextRetryAt(null);
+                downlinkMetricsRecorder.recordFailed();
+            } else {
+                command.setStatus(DeviceCommandStatus.SENT);
+                command.setNextRetryAt(now.plus(commandRetryInterval));
+                downlinkMetricsRecorder.recordRetried();
+            }
+            command.setErrorMessage(ex.getMessage());
+        }
+        deviceCommandRepository.save(command);
+    }
+}

--- a/src/main/java/com/iot/IoT/service/DeviceCommandService.java
+++ b/src/main/java/com/iot/IoT/service/DeviceCommandService.java
@@ -1,0 +1,186 @@
+package com.iot.IoT.service;
+
+import com.iot.IoT.control.ControlAction;
+import com.iot.IoT.dto.DeviceCommandResponse;
+import com.iot.IoT.entity.Device;
+import com.iot.IoT.entity.DeviceCommand;
+import com.iot.IoT.entity.DeviceCommandStatus;
+import com.iot.IoT.mqtt.port.DeviceCommandPublisherPort;
+import com.iot.IoT.repository.DeviceCommandRepository;
+import com.iot.IoT.repository.DeviceRepository;
+import com.iot.IoT.service.exception.DeviceCommandNotFoundException;
+import com.iot.IoT.service.exception.DeviceNotFoundException;
+import com.iot.IoT.service.metrics.DownlinkMetricsRecorder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+@Service
+public class DeviceCommandService {
+
+    private final DeviceRepository deviceRepository;
+    private final DeviceCommandRepository deviceCommandRepository;
+    private final DeviceCommandPublisherPort deviceCommandPublisherPort;
+    private final DownlinkMetricsRecorder downlinkMetricsRecorder;
+    private final Duration commandRetryInterval;
+    private final Duration commandAckTimeout;
+    private final Duration autoControlDedupWindow;
+    private final int commandMaxRetries;
+
+    public DeviceCommandService(
+            DeviceRepository deviceRepository,
+            DeviceCommandRepository deviceCommandRepository,
+            DeviceCommandPublisherPort deviceCommandPublisherPort,
+            DownlinkMetricsRecorder downlinkMetricsRecorder,
+            @Value("${downlink.retry-interval-seconds:10}") long commandRetryIntervalSeconds,
+            @Value("${downlink.ack-timeout-seconds:30}") long commandAckTimeoutSeconds,
+            @Value("${control.auto-command-dedup-window-seconds:30}") long autoControlDedupWindowSeconds,
+            @Value("${downlink.max-retries:3}") int commandMaxRetries
+    ) {
+        this.deviceRepository = deviceRepository;
+        this.deviceCommandRepository = deviceCommandRepository;
+        this.deviceCommandPublisherPort = deviceCommandPublisherPort;
+        this.downlinkMetricsRecorder = downlinkMetricsRecorder;
+        this.commandRetryInterval = Duration.ofSeconds(commandRetryIntervalSeconds);
+        this.commandAckTimeout = Duration.ofSeconds(commandAckTimeoutSeconds);
+        this.autoControlDedupWindow = Duration.ofSeconds(Math.max(autoControlDedupWindowSeconds, 1));
+        this.commandMaxRetries = Math.max(commandMaxRetries, 0);
+    }
+
+    @Transactional
+    public DeviceCommandResponse sendCommand(Long id, ControlAction commandType, String idempotencyKey) {
+        return sendCommand(findEntity(id), commandType, idempotencyKey);
+    }
+
+    @Transactional
+    public DeviceCommandResponse acknowledgeCommand(Long id, Long commandId) {
+        Device device = findEntity(id);
+        DeviceCommand command = deviceCommandRepository.findByIdAndDevicePk(commandId, device.getId())
+                .orElseThrow(() -> new DeviceCommandNotFoundException(device.getId(), commandId));
+
+        if (command.getStatus() != DeviceCommandStatus.ACKED) {
+            command.setStatus(DeviceCommandStatus.ACKED);
+            command.setAckedAt(Instant.now());
+            command.setNextRetryAt(null);
+            command.setErrorMessage(null);
+            command = deviceCommandRepository.save(command);
+            downlinkMetricsRecorder.recordAcked();
+        }
+        return toCommandResponse(command);
+    }
+
+    @Transactional
+    public void sendAutoControlCommand(String deviceId, ControlAction commandType, Instant decidedAt) {
+        if (commandType == ControlAction.HOLD) {
+            return;
+        }
+
+        String normalizedDeviceId = normalize(deviceId);
+        if (normalizedDeviceId == null || normalizedDeviceId.isBlank()) {
+            return;
+        }
+
+        Optional<Device> device = deviceRepository.findByDeviceId(normalizedDeviceId);
+        if (device.isEmpty() || !device.get().isEnabled()) {
+            return;
+        }
+
+        String idempotencyKey = buildAutoControlIdempotencyKey(normalizedDeviceId, commandType, decidedAt);
+        sendCommand(device.get(), commandType, idempotencyKey);
+    }
+
+    private DeviceCommandResponse sendCommand(Device device, ControlAction commandType, String idempotencyKey) {
+        Optional<DeviceCommand> existing = deviceCommandRepository.findByDevicePkAndIdempotencyKey(
+                device.getId(),
+                idempotencyKey
+        );
+        if (existing.isPresent()) {
+            downlinkMetricsRecorder.recordIdempotencyHit();
+            return toCommandResponse(existing.get());
+        }
+
+        String topic = buildCommandTopic(device.getDeviceId());
+
+        DeviceCommand command = new DeviceCommand();
+        command.setDevicePk(device.getId());
+        command.setDeviceId(device.getDeviceId());
+        command.setIdempotencyKey(idempotencyKey);
+        command.setCommandType(commandType);
+        command.setStatus(DeviceCommandStatus.PENDING);
+        command.setRetryCount(0);
+        command.setMaxRetries(commandMaxRetries);
+        command.setTopic(topic);
+        command.setPayload("");
+
+        DeviceCommand created = deviceCommandRepository.save(command);
+        if (created.getId() == null) {
+            throw new IllegalStateException("Device command id was not generated");
+        }
+        Instant requestedAt = created.getRequestedAt() == null ? Instant.now() : created.getRequestedAt();
+        created.setRequestedAt(requestedAt);
+        created.setExpireAt(requestedAt.plus(commandAckTimeout));
+        String payload = buildCommandPayload(created.getId(), commandType, requestedAt);
+        created.setPayload(payload);
+
+        try {
+            deviceCommandPublisherPort.publish(topic, payload);
+            Instant sentAt = Instant.now();
+            created.setStatus(DeviceCommandStatus.SENT);
+            created.setSentAt(sentAt);
+            created.setNextRetryAt(sentAt.plus(commandRetryInterval));
+            created.setErrorMessage(null);
+            downlinkMetricsRecorder.recordSent();
+        } catch (RuntimeException ex) {
+            created.setStatus(DeviceCommandStatus.FAILED);
+            created.setSentAt(null);
+            created.setNextRetryAt(null);
+            created.setErrorMessage(ex.getMessage());
+            downlinkMetricsRecorder.recordFailed();
+        }
+
+        return toCommandResponse(deviceCommandRepository.save(created));
+    }
+
+    private Device findEntity(Long id) {
+        return deviceRepository.findById(id)
+                .orElseThrow(() -> new DeviceNotFoundException(id));
+    }
+
+    private DeviceCommandResponse toCommandResponse(DeviceCommand command) {
+        return new DeviceCommandResponse(
+                command.getId(),
+                command.getDevicePk(),
+                command.getDeviceId(),
+                command.getCommandType(),
+                command.getStatus(),
+                command.getTopic(),
+                command.getPayload(),
+                command.getRequestedAt(),
+                command.getSentAt(),
+                command.getErrorMessage()
+        );
+    }
+
+    private static String normalize(String value) {
+        return value == null ? null : value.trim();
+    }
+
+    private String buildCommandTopic(String deviceId) {
+        return "devices/%s/cmd".formatted(deviceId);
+    }
+
+    private String buildCommandPayload(Long commandId, ControlAction commandType, Instant requestedAt) {
+        return """
+                {"commandId":%d,"commandType":"%s","requestedAt":"%s"}
+                """.formatted(commandId, commandType.name(), requestedAt.toString()).trim();
+    }
+
+    private String buildAutoControlIdempotencyKey(String deviceId, ControlAction commandType, Instant decidedAt) {
+        long dedupBucket = decidedAt.toEpochMilli() / autoControlDedupWindow.toMillis();
+        return "auto:%s:%s:%d".formatted(deviceId, commandType.name(), dedupBucket);
+    }
+}

--- a/src/main/java/com/iot/IoT/service/DeviceControlPolicyService.java
+++ b/src/main/java/com/iot/IoT/service/DeviceControlPolicyService.java
@@ -1,0 +1,48 @@
+package com.iot.IoT.service;
+
+import com.iot.IoT.dto.DeviceControlPolicyResponse;
+import com.iot.IoT.entity.Device;
+import com.iot.IoT.repository.DeviceRepository;
+import com.iot.IoT.service.exception.DeviceNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+@Service
+public class DeviceControlPolicyService {
+
+    private final DeviceRepository deviceRepository;
+
+    public DeviceControlPolicyService(DeviceRepository deviceRepository) {
+        this.deviceRepository = deviceRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public DeviceControlPolicyResponse getControlPolicy(Long id) {
+        return toControlPolicyResponse(findEntity(id));
+    }
+
+    @Transactional
+    public DeviceControlPolicyResponse updateControlPolicy(Long id, BigDecimal targetTemp, BigDecimal hysteresis) {
+        Device device = findEntity(id);
+        device.setControlTargetTemp(targetTemp);
+        device.setControlHysteresis(hysteresis);
+        return toControlPolicyResponse(deviceRepository.save(device));
+    }
+
+    private Device findEntity(Long id) {
+        return deviceRepository.findById(id)
+                .orElseThrow(() -> new DeviceNotFoundException(id));
+    }
+
+    private DeviceControlPolicyResponse toControlPolicyResponse(Device device) {
+        return new DeviceControlPolicyResponse(
+                device.getId(),
+                device.getDeviceId(),
+                device.getControlTargetTemp(),
+                device.getControlHysteresis(),
+                device.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/iot/IoT/service/DeviceQueryService.java
+++ b/src/main/java/com/iot/IoT/service/DeviceQueryService.java
@@ -1,0 +1,256 @@
+package com.iot.IoT.service;
+
+import com.iot.IoT.dto.CreateDeviceRequest;
+import com.iot.IoT.dto.DeviceCommandPageResponse;
+import com.iot.IoT.dto.DeviceCommandResponse;
+import com.iot.IoT.dto.DevicePageResponse;
+import com.iot.IoT.dto.DeviceResponse;
+import com.iot.IoT.dto.DeviceStatusResponse;
+import com.iot.IoT.dto.DeviceTemperaturePointResponse;
+import com.iot.IoT.dto.DeviceTemperatureSeriesResponse;
+import com.iot.IoT.entity.Device;
+import com.iot.IoT.entity.DeviceCommand;
+import com.iot.IoT.ingestion.port.TemperatureTimeSeriesQueryPort;
+import com.iot.IoT.repository.DeviceCommandRepository;
+import com.iot.IoT.repository.DeviceRepository;
+import com.iot.IoT.service.exception.DeviceNotFoundException;
+import com.iot.IoT.service.exception.DuplicateDeviceException;
+import com.iot.IoT.service.exception.InvalidDeviceQueryException;
+import com.iot.IoT.watchdog.port.WatchdogStatePort;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class DeviceQueryService {
+
+    private static final int MIN_PAGE_SIZE = 1;
+    private static final int MAX_PAGE_SIZE = 100;
+    private static final int MIN_TEMP_LIMIT = 1;
+    private static final int MAX_TEMP_LIMIT = 500;
+    private static final int DEFAULT_TEMP_LIMIT = 200;
+    private static final int DEFAULT_COMMAND_LIMIT = 20;
+    private static final int MIN_COMMAND_LIMIT = 1;
+    private static final int MAX_COMMAND_LIMIT = 100;
+    private static final Duration DEFAULT_RANGE = Duration.ofHours(1);
+
+    private final DeviceRepository deviceRepository;
+    private final DeviceCommandRepository deviceCommandRepository;
+    private final WatchdogStatePort watchdogStatePort;
+    private final TemperatureTimeSeriesQueryPort temperatureTimeSeriesQueryPort;
+    private final Duration heartbeatTtl;
+
+    public DeviceQueryService(
+            DeviceRepository deviceRepository,
+            DeviceCommandRepository deviceCommandRepository,
+            WatchdogStatePort watchdogStatePort,
+            TemperatureTimeSeriesQueryPort temperatureTimeSeriesQueryPort,
+            @Value("${ingestion.heartbeat-ttl-seconds:120}") long heartbeatTtlSeconds
+    ) {
+        this.deviceRepository = deviceRepository;
+        this.deviceCommandRepository = deviceCommandRepository;
+        this.watchdogStatePort = watchdogStatePort;
+        this.temperatureTimeSeriesQueryPort = temperatureTimeSeriesQueryPort;
+        this.heartbeatTtl = Duration.ofSeconds(heartbeatTtlSeconds);
+    }
+
+    @Transactional
+    public DeviceResponse create(CreateDeviceRequest request) {
+        String normalizedDeviceId = normalize(request.deviceId());
+        if (deviceRepository.existsByDeviceId(normalizedDeviceId)) {
+            throw new DuplicateDeviceException(normalizedDeviceId);
+        }
+
+        Device device = new Device();
+        device.setDeviceId(normalizedDeviceId);
+        device.setName(normalizeNullable(request.name()));
+        device.setEnabled(request.enabled() == null || request.enabled());
+
+        Device saved = deviceRepository.save(device);
+        return toResponse(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public DeviceResponse findById(Long id) {
+        return toResponse(findEntity(id));
+    }
+
+    @Transactional(readOnly = true)
+    public DevicePageResponse findAll(int page, int size) {
+        int normalizedPage = Math.max(page, 0);
+        int normalizedSize = clamp(size, MIN_PAGE_SIZE, MAX_PAGE_SIZE);
+
+        Page<Device> result = deviceRepository.findAll(
+                PageRequest.of(normalizedPage, normalizedSize, Sort.by(Sort.Direction.ASC, "id"))
+        );
+
+        return new DevicePageResponse(
+                result.getContent().stream().map(this::toResponse).toList(),
+                result.getTotalElements(),
+                result.getTotalPages(),
+                normalizedPage,
+                normalizedSize
+        );
+    }
+
+    @Transactional
+    public DeviceResponse updateEnabled(Long id, boolean enabled) {
+        Device device = findEntity(id);
+        device.setEnabled(enabled);
+        return toResponse(deviceRepository.save(device));
+    }
+
+    @Transactional(readOnly = true)
+    public DeviceStatusResponse getStatus(Long id) {
+        Device device = findEntity(id);
+        Optional<Instant> lastSeen = watchdogStatePort.findLastSeen(device.getDeviceId());
+        Optional<DeviceTemperaturePointResponse> latest = temperatureTimeSeriesQueryPort.findLatest(device.getDeviceId());
+
+        return new DeviceStatusResponse(
+                device.getId(),
+                device.getDeviceId(),
+                device.getName(),
+                device.isEnabled(),
+                lastSeen.orElse(null),
+                isOnline(lastSeen),
+                latest.map(DeviceTemperaturePointResponse::temp).orElse(null),
+                latest.map(DeviceTemperaturePointResponse::targetTemp).orElse(null),
+                latest.map(DeviceTemperaturePointResponse::state).orElse(null),
+                latest.map(DeviceTemperaturePointResponse::occurredAt).orElse(null)
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public DeviceTemperatureSeriesResponse getTemperatures(Long id, Instant from, Instant to, int limit) {
+        Device device = findEntity(id);
+        Range range = resolveRange(from, to);
+        int normalizedLimit = normalizeTempLimit(limit);
+        List<DeviceTemperaturePointResponse> items = temperatureTimeSeriesQueryPort.findRange(
+                device.getDeviceId(),
+                range.from(),
+                range.to(),
+                normalizedLimit
+        );
+
+        return new DeviceTemperatureSeriesResponse(
+                device.getId(),
+                device.getDeviceId(),
+                range.from(),
+                range.to(),
+                normalizedLimit,
+                items
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public DeviceCommandPageResponse getCommands(Long id, int limit) {
+        Device device = findEntity(id);
+        int normalizedLimit = normalizeCommandLimit(limit);
+        List<DeviceCommandResponse> items = deviceCommandRepository.findByDevicePkOrderByRequestedAtDesc(
+                        device.getId(),
+                        PageRequest.of(0, normalizedLimit)
+                ).stream()
+                .map(this::toCommandResponse)
+                .toList();
+        return new DeviceCommandPageResponse(device.getId(), device.getDeviceId(), normalizedLimit, items);
+    }
+
+    private Device findEntity(Long id) {
+        return deviceRepository.findById(id)
+                .orElseThrow(() -> new DeviceNotFoundException(id));
+    }
+
+    private DeviceResponse toResponse(Device device) {
+        return new DeviceResponse(
+                device.getId(),
+                device.getDeviceId(),
+                device.getName(),
+                device.isEnabled(),
+                device.getCreatedAt(),
+                device.getUpdatedAt()
+        );
+    }
+
+    private DeviceCommandResponse toCommandResponse(DeviceCommand command) {
+        return new DeviceCommandResponse(
+                command.getId(),
+                command.getDevicePk(),
+                command.getDeviceId(),
+                command.getCommandType(),
+                command.getStatus(),
+                command.getTopic(),
+                command.getPayload(),
+                command.getRequestedAt(),
+                command.getSentAt(),
+                command.getErrorMessage()
+        );
+    }
+
+    private boolean isOnline(Optional<Instant> lastSeen) {
+        if (lastSeen.isEmpty()) {
+            return false;
+        }
+        Instant onlineThreshold = Instant.now().minus(heartbeatTtl);
+        return !lastSeen.get().isBefore(onlineThreshold);
+    }
+
+    private int normalizeTempLimit(int limit) {
+        if (limit == 0) {
+            return DEFAULT_TEMP_LIMIT;
+        }
+        if (limit < MIN_TEMP_LIMIT || limit > MAX_TEMP_LIMIT) {
+            throw new InvalidDeviceQueryException(
+                    "limit must be between %d and %d".formatted(MIN_TEMP_LIMIT, MAX_TEMP_LIMIT)
+            );
+        }
+        return limit;
+    }
+
+    private int normalizeCommandLimit(int limit) {
+        if (limit == 0) {
+            return DEFAULT_COMMAND_LIMIT;
+        }
+        if (limit < MIN_COMMAND_LIMIT || limit > MAX_COMMAND_LIMIT) {
+            throw new InvalidDeviceQueryException(
+                    "limit must be between %d and %d".formatted(MIN_COMMAND_LIMIT, MAX_COMMAND_LIMIT)
+            );
+        }
+        return limit;
+    }
+
+    private Range resolveRange(Instant from, Instant to) {
+        Instant resolvedTo = to == null ? Instant.now() : to;
+        Instant resolvedFrom = from == null ? resolvedTo.minus(DEFAULT_RANGE) : from;
+        if (resolvedFrom.isAfter(resolvedTo)) {
+            throw new InvalidDeviceQueryException("from must be before or equal to to");
+        }
+        return new Range(resolvedFrom, resolvedTo);
+    }
+
+    private static String normalize(String value) {
+        return value == null ? null : value.trim();
+    }
+
+    private static String normalizeNullable(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private static int clamp(int value, int min, int max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    private record Range(Instant from, Instant to) {
+    }
+}

--- a/src/main/java/com/iot/IoT/service/DeviceServiceImpl.java
+++ b/src/main/java/com/iot/IoT/service/DeviceServiceImpl.java
@@ -8,482 +8,94 @@ import com.iot.IoT.dto.DeviceControlPolicyResponse;
 import com.iot.IoT.dto.DevicePageResponse;
 import com.iot.IoT.dto.DeviceResponse;
 import com.iot.IoT.dto.DeviceStatusResponse;
-import com.iot.IoT.dto.DeviceTemperaturePointResponse;
 import com.iot.IoT.dto.DeviceTemperatureSeriesResponse;
-import com.iot.IoT.entity.Device;
-import com.iot.IoT.entity.DeviceCommand;
-import com.iot.IoT.entity.DeviceCommandStatus;
-import com.iot.IoT.ingestion.port.TemperatureTimeSeriesQueryPort;
-import com.iot.IoT.mqtt.port.DeviceCommandPublisherPort;
-import com.iot.IoT.repository.DeviceCommandRepository;
-import com.iot.IoT.repository.DeviceRepository;
-import com.iot.IoT.service.exception.DeviceCommandNotFoundException;
-import com.iot.IoT.service.exception.DeviceNotFoundException;
-import com.iot.IoT.service.exception.DuplicateDeviceException;
-import com.iot.IoT.service.exception.InvalidDeviceQueryException;
-import com.iot.IoT.service.metrics.DownlinkMetricsRecorder;
-import com.iot.IoT.watchdog.port.WatchdogStatePort;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.time.Duration;
 import java.time.Instant;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Optional;
 
 @Service
 public class DeviceServiceImpl implements DeviceService {
 
-    private static final int MIN_PAGE_SIZE = 1;
-    private static final int MAX_PAGE_SIZE = 100;
-    private static final int MIN_TEMP_LIMIT = 1;
-    private static final int MAX_TEMP_LIMIT = 500;
-    private static final int DEFAULT_TEMP_LIMIT = 200;
-    private static final int DEFAULT_COMMAND_LIMIT = 20;
-    private static final int MIN_COMMAND_LIMIT = 1;
-    private static final int MAX_COMMAND_LIMIT = 100;
-    private static final Duration DEFAULT_RANGE = Duration.ofHours(1);
-    private static final EnumSet<DeviceCommandStatus> RELIABILITY_TARGET_STATUSES =
-            EnumSet.of(DeviceCommandStatus.SENT, DeviceCommandStatus.PENDING);
-
-    private final DeviceRepository deviceRepository;
-    private final DeviceCommandRepository deviceCommandRepository;
-    private final WatchdogStatePort watchdogStatePort;
-    private final TemperatureTimeSeriesQueryPort temperatureTimeSeriesQueryPort;
-    private final DeviceCommandPublisherPort deviceCommandPublisherPort;
-    private final DownlinkMetricsRecorder downlinkMetricsRecorder;
-    private final Duration heartbeatTtl;
-    private final Duration commandRetryInterval;
-    private final Duration commandAckTimeout;
-    private final Duration autoControlDedupWindow;
-    private final int commandMaxRetries;
+    private final DeviceQueryService deviceQueryService;
+    private final DeviceControlPolicyService deviceControlPolicyService;
+    private final DeviceCommandService deviceCommandService;
+    private final DeviceCommandReliabilityService deviceCommandReliabilityService;
 
     public DeviceServiceImpl(
-            DeviceRepository deviceRepository,
-            DeviceCommandRepository deviceCommandRepository,
-            WatchdogStatePort watchdogStatePort,
-            TemperatureTimeSeriesQueryPort temperatureTimeSeriesQueryPort,
-            DeviceCommandPublisherPort deviceCommandPublisherPort,
-            DownlinkMetricsRecorder downlinkMetricsRecorder,
-            @Value("${ingestion.heartbeat-ttl-seconds:120}") long heartbeatTtlSeconds,
-            @Value("${downlink.retry-interval-seconds:10}") long commandRetryIntervalSeconds,
-            @Value("${downlink.ack-timeout-seconds:30}") long commandAckTimeoutSeconds,
-            @Value("${control.auto-command-dedup-window-seconds:30}") long autoControlDedupWindowSeconds,
-            @Value("${downlink.max-retries:3}") int commandMaxRetries
+            DeviceQueryService deviceQueryService,
+            DeviceControlPolicyService deviceControlPolicyService,
+            DeviceCommandService deviceCommandService,
+            DeviceCommandReliabilityService deviceCommandReliabilityService
     ) {
-        this.deviceRepository = deviceRepository;
-        this.deviceCommandRepository = deviceCommandRepository;
-        this.watchdogStatePort = watchdogStatePort;
-        this.temperatureTimeSeriesQueryPort = temperatureTimeSeriesQueryPort;
-        this.deviceCommandPublisherPort = deviceCommandPublisherPort;
-        this.downlinkMetricsRecorder = downlinkMetricsRecorder;
-        this.heartbeatTtl = Duration.ofSeconds(heartbeatTtlSeconds);
-        this.commandRetryInterval = Duration.ofSeconds(commandRetryIntervalSeconds);
-        this.commandAckTimeout = Duration.ofSeconds(commandAckTimeoutSeconds);
-        this.autoControlDedupWindow = Duration.ofSeconds(Math.max(autoControlDedupWindowSeconds, 1));
-        this.commandMaxRetries = Math.max(commandMaxRetries, 0);
+        this.deviceQueryService = deviceQueryService;
+        this.deviceControlPolicyService = deviceControlPolicyService;
+        this.deviceCommandService = deviceCommandService;
+        this.deviceCommandReliabilityService = deviceCommandReliabilityService;
     }
 
     @Override
-    @Transactional
     public DeviceResponse create(CreateDeviceRequest request) {
-        String normalizedDeviceId = normalize(request.deviceId());
-        if (deviceRepository.existsByDeviceId(normalizedDeviceId)) {
-            throw new DuplicateDeviceException(normalizedDeviceId);
-        }
-
-        Device device = new Device();
-        device.setDeviceId(normalizedDeviceId);
-        device.setName(normalizeNullable(request.name()));
-        device.setEnabled(request.enabled() == null || request.enabled());
-
-        Device saved = deviceRepository.save(device);
-        return toResponse(saved);
+        return deviceQueryService.create(request);
     }
 
     @Override
-    @Transactional(readOnly = true)
     public DeviceResponse findById(Long id) {
-        Device device = findEntity(id);
-        return toResponse(device);
+        return deviceQueryService.findById(id);
     }
 
     @Override
-    @Transactional(readOnly = true)
     public DevicePageResponse findAll(int page, int size) {
-        int normalizedPage = Math.max(page, 0);
-        int normalizedSize = clamp(size, MIN_PAGE_SIZE, MAX_PAGE_SIZE);
-
-        Page<Device> result = deviceRepository.findAll(
-                PageRequest.of(normalizedPage, normalizedSize, Sort.by(Sort.Direction.ASC, "id"))
-        );
-
-        return new DevicePageResponse(
-                result.getContent().stream().map(this::toResponse).toList(),
-                result.getTotalElements(),
-                result.getTotalPages(),
-                normalizedPage,
-                normalizedSize
-        );
+        return deviceQueryService.findAll(page, size);
     }
 
     @Override
-    @Transactional
     public DeviceResponse updateEnabled(Long id, boolean enabled) {
-        Device device = findEntity(id);
-        device.setEnabled(enabled);
-        Device updated = deviceRepository.save(device);
-        return toResponse(updated);
+        return deviceQueryService.updateEnabled(id, enabled);
     }
 
     @Override
-    @Transactional(readOnly = true)
     public DeviceStatusResponse getStatus(Long id) {
-        Device device = findEntity(id);
-        Optional<Instant> lastSeen = watchdogStatePort.findLastSeen(device.getDeviceId());
-        Optional<DeviceTemperaturePointResponse> latest = temperatureTimeSeriesQueryPort.findLatest(device.getDeviceId());
-
-        return new DeviceStatusResponse(
-                device.getId(),
-                device.getDeviceId(),
-                device.getName(),
-                device.isEnabled(),
-                lastSeen.orElse(null),
-                isOnline(lastSeen),
-                latest.map(DeviceTemperaturePointResponse::temp).orElse(null),
-                latest.map(DeviceTemperaturePointResponse::targetTemp).orElse(null),
-                latest.map(DeviceTemperaturePointResponse::state).orElse(null),
-                latest.map(DeviceTemperaturePointResponse::occurredAt).orElse(null)
-        );
+        return deviceQueryService.getStatus(id);
     }
 
     @Override
-    @Transactional(readOnly = true)
     public DeviceTemperatureSeriesResponse getTemperatures(Long id, Instant from, Instant to, int limit) {
-        Device device = findEntity(id);
-        Range range = resolveRange(from, to);
-        int normalizedLimit = normalizeTempLimit(limit);
-        List<DeviceTemperaturePointResponse> items = temperatureTimeSeriesQueryPort.findRange(
-                device.getDeviceId(),
-                range.from(),
-                range.to(),
-                normalizedLimit
-        );
-
-        return new DeviceTemperatureSeriesResponse(
-                device.getId(),
-                device.getDeviceId(),
-                range.from(),
-                range.to(),
-                normalizedLimit,
-                items
-        );
+        return deviceQueryService.getTemperatures(id, from, to, limit);
     }
 
     @Override
-    @Transactional(readOnly = true)
     public DeviceControlPolicyResponse getControlPolicy(Long id) {
-        Device device = findEntity(id);
-        return toControlPolicyResponse(device);
+        return deviceControlPolicyService.getControlPolicy(id);
     }
 
     @Override
-    @Transactional
     public DeviceControlPolicyResponse updateControlPolicy(Long id, BigDecimal targetTemp, BigDecimal hysteresis) {
-        Device device = findEntity(id);
-        device.setControlTargetTemp(targetTemp);
-        device.setControlHysteresis(hysteresis);
-        Device updated = deviceRepository.save(device);
-        return toControlPolicyResponse(updated);
+        return deviceControlPolicyService.updateControlPolicy(id, targetTemp, hysteresis);
     }
 
     @Override
-    @Transactional
     public DeviceCommandResponse sendCommand(Long id, ControlAction commandType, String idempotencyKey) {
-        Device device = findEntity(id);
-        Optional<DeviceCommand> existing = deviceCommandRepository.findByDevicePkAndIdempotencyKey(
-                device.getId(),
-                idempotencyKey
-        );
-        if (existing.isPresent()) {
-            downlinkMetricsRecorder.recordIdempotencyHit();
-            return toCommandResponse(existing.get());
-        }
-
-        String topic = buildCommandTopic(device.getDeviceId());
-
-        DeviceCommand command = new DeviceCommand();
-        command.setDevicePk(device.getId());
-        command.setDeviceId(device.getDeviceId());
-        command.setIdempotencyKey(idempotencyKey);
-        command.setCommandType(commandType);
-        command.setStatus(DeviceCommandStatus.PENDING);
-        command.setRetryCount(0);
-        command.setMaxRetries(commandMaxRetries);
-        command.setTopic(topic);
-        command.setPayload("");
-
-        DeviceCommand created = deviceCommandRepository.save(command);
-        if (created.getId() == null) {
-            throw new IllegalStateException("Device command id was not generated");
-        }
-        Instant requestedAt = created.getRequestedAt() == null ? Instant.now() : created.getRequestedAt();
-        created.setRequestedAt(requestedAt);
-        created.setExpireAt(requestedAt.plus(commandAckTimeout));
-        String payload = buildCommandPayload(created.getId(), commandType, requestedAt);
-        created.setPayload(payload);
-
-        try {
-            deviceCommandPublisherPort.publish(topic, payload);
-            Instant sentAt = Instant.now();
-            created.setStatus(DeviceCommandStatus.SENT);
-            created.setSentAt(sentAt);
-            created.setNextRetryAt(sentAt.plus(commandRetryInterval));
-            created.setErrorMessage(null);
-            downlinkMetricsRecorder.recordSent();
-        } catch (RuntimeException ex) {
-            created.setStatus(DeviceCommandStatus.FAILED);
-            created.setSentAt(null);
-            created.setNextRetryAt(null);
-            created.setErrorMessage(ex.getMessage());
-            downlinkMetricsRecorder.recordFailed();
-        }
-
-        DeviceCommand saved = deviceCommandRepository.save(created);
-        return toCommandResponse(saved);
+        return deviceCommandService.sendCommand(id, commandType, idempotencyKey);
     }
 
     @Override
-    @Transactional(readOnly = true)
     public DeviceCommandPageResponse getCommands(Long id, int limit) {
-        Device device = findEntity(id);
-        int normalizedLimit = normalizeCommandLimit(limit);
-        List<DeviceCommandResponse> items = deviceCommandRepository.findByDevicePkOrderByRequestedAtDesc(
-                        device.getId(),
-                        PageRequest.of(0, normalizedLimit)
-                ).stream()
-                .map(this::toCommandResponse)
-                .toList();
-        return new DeviceCommandPageResponse(device.getId(), device.getDeviceId(), normalizedLimit, items);
+        return deviceQueryService.getCommands(id, limit);
     }
 
     @Override
-    @Transactional
     public DeviceCommandResponse acknowledgeCommand(Long id, Long commandId) {
-        Device device = findEntity(id);
-        DeviceCommand command = deviceCommandRepository.findByIdAndDevicePk(commandId, device.getId())
-                .orElseThrow(() -> new DeviceCommandNotFoundException(device.getId(), commandId));
-
-        if (command.getStatus() != DeviceCommandStatus.ACKED) {
-            command.setStatus(DeviceCommandStatus.ACKED);
-            command.setAckedAt(Instant.now());
-            command.setNextRetryAt(null);
-            command.setErrorMessage(null);
-            command = deviceCommandRepository.save(command);
-            downlinkMetricsRecorder.recordAcked();
-        }
-        return toCommandResponse(command);
+        return deviceCommandService.acknowledgeCommand(id, commandId);
     }
 
     @Override
-    @Transactional
     public void sendAutoControlCommand(String deviceId, ControlAction commandType, Instant decidedAt) {
-        if (commandType == ControlAction.HOLD) {
-            return;
-        }
-
-        String normalizedDeviceId = normalize(deviceId);
-        if (normalizedDeviceId == null || normalizedDeviceId.isBlank()) {
-            return;
-        }
-
-        Optional<Device> device = deviceRepository.findByDeviceId(normalizedDeviceId);
-        if (device.isEmpty() || !device.get().isEnabled()) {
-            return;
-        }
-
-        String idempotencyKey = buildAutoControlIdempotencyKey(normalizedDeviceId, commandType, decidedAt);
-        sendCommand(device.get().getId(), commandType, idempotencyKey);
+        deviceCommandService.sendAutoControlCommand(deviceId, commandType, decidedAt);
     }
 
     @Override
-    @Transactional
     public void processCommandReliability() {
-        Instant now = Instant.now();
-        List<DeviceCommand> targets = deviceCommandRepository.findByStatusIn(RELIABILITY_TARGET_STATUSES);
-        for (DeviceCommand command : targets) {
-            if (command.getStatus() == DeviceCommandStatus.ACKED
-                    || command.getStatus() == DeviceCommandStatus.EXPIRED
-                    || command.getStatus() == DeviceCommandStatus.FAILED) {
-                continue;
-            }
-            if (command.getExpireAt() != null && now.isAfter(command.getExpireAt())) {
-                command.setStatus(DeviceCommandStatus.EXPIRED);
-                command.setNextRetryAt(null);
-                command.setErrorMessage("ack timeout expired");
-                deviceCommandRepository.save(command);
-                downlinkMetricsRecorder.recordExpired();
-                continue;
-            }
-            if (command.getStatus() == DeviceCommandStatus.PENDING) {
-                retryPublish(command, now);
-                continue;
-            }
-            if (command.getStatus() == DeviceCommandStatus.SENT
-                    && command.getNextRetryAt() != null
-                    && !now.isBefore(command.getNextRetryAt())
-                    && command.getRetryCount() < command.getMaxRetries()) {
-                retryPublish(command, now);
-            }
-        }
-    }
-
-    private Device findEntity(Long id) {
-        return deviceRepository.findById(id)
-                .orElseThrow(() -> new DeviceNotFoundException(id));
-    }
-
-    private DeviceResponse toResponse(Device device) {
-        return new DeviceResponse(
-                device.getId(),
-                device.getDeviceId(),
-                device.getName(),
-                device.isEnabled(),
-                device.getCreatedAt(),
-                device.getUpdatedAt()
-        );
-    }
-
-    private DeviceControlPolicyResponse toControlPolicyResponse(Device device) {
-        return new DeviceControlPolicyResponse(
-                device.getId(),
-                device.getDeviceId(),
-                device.getControlTargetTemp(),
-                device.getControlHysteresis(),
-                device.getUpdatedAt()
-        );
-    }
-
-    private DeviceCommandResponse toCommandResponse(DeviceCommand command) {
-        return new DeviceCommandResponse(
-                command.getId(),
-                command.getDevicePk(),
-                command.getDeviceId(),
-                command.getCommandType(),
-                command.getStatus(),
-                command.getTopic(),
-                command.getPayload(),
-                command.getRequestedAt(),
-                command.getSentAt(),
-                command.getErrorMessage()
-        );
-    }
-
-    private void retryPublish(DeviceCommand command, Instant now) {
-        try {
-            deviceCommandPublisherPort.publish(command.getTopic(), command.getPayload());
-            command.setStatus(DeviceCommandStatus.SENT);
-            command.setSentAt(now);
-            command.setRetryCount(command.getRetryCount() + 1);
-            command.setNextRetryAt(now.plus(commandRetryInterval));
-            command.setErrorMessage(null);
-            downlinkMetricsRecorder.recordRetried();
-            downlinkMetricsRecorder.recordSent();
-        } catch (RuntimeException ex) {
-            int nextRetry = command.getRetryCount() + 1;
-            command.setRetryCount(nextRetry);
-            if (nextRetry >= command.getMaxRetries()) {
-                command.setStatus(DeviceCommandStatus.FAILED);
-                command.setNextRetryAt(null);
-                downlinkMetricsRecorder.recordFailed();
-            } else {
-                command.setStatus(DeviceCommandStatus.SENT);
-                command.setNextRetryAt(now.plus(commandRetryInterval));
-                downlinkMetricsRecorder.recordRetried();
-            }
-            command.setErrorMessage(ex.getMessage());
-        }
-        deviceCommandRepository.save(command);
-    }
-
-    private static String normalize(String value) {
-        return value == null ? null : value.trim();
-    }
-
-    private static String normalizeNullable(String value) {
-        if (value == null) {
-            return null;
-        }
-        String trimmed = value.trim();
-        return trimmed.isEmpty() ? null : trimmed;
-    }
-
-    private static int clamp(int value, int min, int max) {
-        return Math.max(min, Math.min(max, value));
-    }
-
-    private boolean isOnline(Optional<Instant> lastSeen) {
-        if (lastSeen.isEmpty()) {
-            return false;
-        }
-        Instant onlineThreshold = Instant.now().minus(heartbeatTtl);
-        return !lastSeen.get().isBefore(onlineThreshold);
-    }
-
-    private int normalizeTempLimit(int limit) {
-        if (limit == 0) {
-            return DEFAULT_TEMP_LIMIT;
-        }
-        if (limit < MIN_TEMP_LIMIT || limit > MAX_TEMP_LIMIT) {
-            throw new InvalidDeviceQueryException(
-                    "limit must be between %d and %d".formatted(MIN_TEMP_LIMIT, MAX_TEMP_LIMIT)
-            );
-        }
-        return limit;
-    }
-
-    private int normalizeCommandLimit(int limit) {
-        if (limit == 0) {
-            return DEFAULT_COMMAND_LIMIT;
-        }
-        if (limit < MIN_COMMAND_LIMIT || limit > MAX_COMMAND_LIMIT) {
-            throw new InvalidDeviceQueryException(
-                    "limit must be between %d and %d".formatted(MIN_COMMAND_LIMIT, MAX_COMMAND_LIMIT)
-            );
-        }
-        return limit;
-    }
-
-    private String buildCommandTopic(String deviceId) {
-        return "devices/%s/cmd".formatted(deviceId);
-    }
-
-    private String buildCommandPayload(Long commandId, ControlAction commandType, Instant requestedAt) {
-        return """
-                {"commandId":%d,"commandType":"%s","requestedAt":"%s"}
-                """.formatted(commandId, commandType.name(), requestedAt.toString()).trim();
-    }
-
-    private String buildAutoControlIdempotencyKey(String deviceId, ControlAction commandType, Instant decidedAt) {
-        long dedupBucket = decidedAt.toEpochMilli() / autoControlDedupWindow.toMillis();
-        return "auto:%s:%s:%d".formatted(deviceId, commandType.name(), dedupBucket);
-    }
-
-    private Range resolveRange(Instant from, Instant to) {
-        Instant resolvedTo = to == null ? Instant.now() : to;
-        Instant resolvedFrom = from == null ? resolvedTo.minus(DEFAULT_RANGE) : from;
-        if (resolvedFrom.isAfter(resolvedTo)) {
-            throw new InvalidDeviceQueryException("from must be before or equal to to");
-        }
-        return new Range(resolvedFrom, resolvedTo);
-    }
-
-    private record Range(Instant from, Instant to) {
+        deviceCommandReliabilityService.processCommandReliability();
     }
 }

--- a/src/test/java/com/iot/IoT/service/DeviceServiceImplTest.java
+++ b/src/test/java/com/iot/IoT/service/DeviceServiceImplTest.java
@@ -64,18 +64,35 @@ class DeviceServiceImplTest {
         temperatureTimeSeriesQueryPort = Mockito.mock(TemperatureTimeSeriesQueryPort.class);
         deviceCommandPublisherPort = Mockito.mock(DeviceCommandPublisherPort.class);
         downlinkMetricsRecorder = Mockito.mock(DownlinkMetricsRecorder.class);
-        deviceService = new DeviceServiceImpl(
+        DeviceQueryService deviceQueryService = new DeviceQueryService(
                 deviceRepository,
                 deviceCommandRepository,
                 watchdogStatePort,
                 temperatureTimeSeriesQueryPort,
+                120
+        );
+        DeviceControlPolicyService deviceControlPolicyService = new DeviceControlPolicyService(deviceRepository);
+        DeviceCommandService deviceCommandService = new DeviceCommandService(
+                deviceRepository,
+                deviceCommandRepository,
                 deviceCommandPublisherPort,
                 downlinkMetricsRecorder,
-                120,
                 10,
                 30,
                 30,
                 3
+        );
+        DeviceCommandReliabilityService deviceCommandReliabilityService = new DeviceCommandReliabilityService(
+                deviceCommandRepository,
+                deviceCommandPublisherPort,
+                downlinkMetricsRecorder,
+                10
+        );
+        deviceService = new DeviceServiceImpl(
+                deviceQueryService,
+                deviceControlPolicyService,
+                deviceCommandService,
+                deviceCommandReliabilityService
         );
     }
 


### PR DESCRIPTION
## What Changed
  - `DeviceServiceImpl`를 thin facade로 축소
  - device query 책임을 `DeviceQueryService`로 분리
  - control policy 책임을 `DeviceControlPolicyService`로 분리
  - manual / auto command 발행 책임을 `DeviceCommandService`로 분리
  - ACK / retry / expire 책임을 `DeviceCommandReliabilityService`로 분리
  - `DeviceCommandReliabilityScheduler`가 reliability 전용 서비스에 직접 의존하도록 변경
  - `DeviceServiceImplTest`를 새 구조에 맞게 정리
  - `docs/refactoring-roadmap.md`에 Phase 4 반영

  ## Why
  - 기존 `DeviceServiceImpl`는 query / policy / command / reliability 책임이 모두 몰려 있어 구조 설명력이 낮았음
  - 면접 및 포트폴리오 관점에서 유스케이스 단위 서비스 경계를 코드에서 드러낼 필요가 있었음
  - 이번 변경은 API 계약은 유지하면서 내부 구조만 유스케이스 중심으로 정리하는 데 목적이 있음

  ## How To Verify
  - 테스트 실행
  ./gradlew test

  - 확인 포인트
      - 기존 device API 동작이 유지되는지
      - 수동 command 발행 / auto control command 발행이 기존처럼 동작하는지
      - ACK / retry / expire reliability 흐름이 유지되는지
      - scheduler가 reliability service를 통해 정상 동작하는지

  ## Risks / Limits

  - controller는 아직 DeviceService facade에 의존하고 있어, 내부 구조는 정리됐지만 API 계층이 완전히 유스케이스별 wiring으로 바뀐
    것은 아님
  - 공통 매핑/정규화 로직은 아직 서비스 내부에 남아 있음
  - 서비스별 테스트 파일을 완전히 분리한 단계는 아님

  ## Next Step

  - controller가 필요 시 query / command / policy 유스케이스 서비스에 직접 의존하도록 추가 축소 검토
  - 공통 매핑/validation/normalization 보조 로직 분리
  - 서비스별 단위 테스트 파일 분리
  - 최종 포트폴리오용 README / 아키텍처 설명 문서 정리
 closed #49 