### PR TITLE
docs: organize readme and technical docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,163 @@
+# Smart Sousvide IoT Backend
+
+MQTT 기반 수비드 디바이스 상태 메시지를 수집하고, Redis/InfluxDB에 상태를 반영하며, 제어 정책에 따라 자동 downlink command까지 연결하는 Spring Boot 백엔드입니다. 단순 수집 서버가 아니라 ingestion, control, reliability, observability를 함께 다루는 IoT 운영형 백엔드를 목표로 구현했습니다.
+
+## Overview
+- 디바이스 telemetry를 MQTT로 수신합니다.
+- payload를 strict parse/validation 후 시계열/heartbeat 경로로 분기합니다.
+- watchdog으로 디바이스 오프라인 상태를 감지합니다.
+- 제어 정책에 따라 auto control command를 발행합니다.
+- downlink command는 ACK / retry / expire 흐름을 가집니다.
+- Actuator/Prometheus/Grafana 기반 운영 지표를 노출합니다.
+
+## Tech Stack
+- Language: Java 17
+- Framework: Spring Boot 4, Spring Web, Spring Data JPA, Spring Integration MQTT
+- Database: MySQL
+- State/Cache: Redis
+- Time-series: InfluxDB
+- Messaging: MQTT (Mosquitto broker, Paho/HiveMQ simulator path)
+- Observability: Spring Actuator, Micrometer, Prometheus, Grafana
+- Test/Load: JUnit, Mockito, distributed load test scripts
+
+## Architecture
+```text
+Device
+  -> MQTT status publish
+  -> MqttConsumer
+  -> MqttPayloadParser
+  -> DeviceIngestionService
+     -> InfluxDB temperature series
+     -> Redis heartbeat(lastSeen)
+     -> ControlDecisionEngine
+     -> DeviceCommandService(auto downlink)
+
+Operator/API
+  -> DeviceController
+  -> DeviceService facade
+     -> DeviceQueryService
+     -> DeviceControlPolicyService
+     -> DeviceCommandService
+     -> DeviceCommandReliabilityService
+```
+
+상세 결정 기록:
+- [Ingestion ADR](docs/adr/0001-ingestion-architecture.md)
+
+## Core Features
+- Device management API
+  - 디바이스 등록, 조회, 목록, enabled 변경
+- Device status/temperature API
+  - 현재 상태 스냅샷 조회
+  - 온도 시계열 구간 조회
+- Control policy API
+  - target temperature / hysteresis 조회 및 변경
+- Downlink command API
+  - 수동 command 발행
+  - command history 조회
+  - ACK 반영
+- Auto control loop
+  - telemetry -> control decision -> auto command dispatch
+- Reliability policy
+  - duplicate suppression
+  - parse dead-letter classification
+  - storage/control replay candidate classification
+- Observability
+  - ingestion/downlink 메트릭 노출
+  - Prometheus/Grafana 연동 기반 제공
+
+## API Summary
+주요 endpoint:
+- `POST /devices`
+- `GET /devices/{id}`
+- `GET /devices/{id}/status`
+- `GET /devices/{id}/temps`
+- `GET /devices/{id}/control-policy`
+- `PATCH /devices/{id}/control-policy`
+- `POST /devices/{id}/commands`
+- `GET /devices/{id}/commands`
+- `POST /devices/{id}/commands/{commandId}/ack`
+
+상세 계약:
+- [Device API](docs/device-api.md)
+- [Swagger Guide](docs/swagger.md)
+
+## Reliability And Observability
+현재 반영된 신뢰성 정책:
+- invalid JSON / validation failure는 non-replayable parse failure로 분류
+- Influx/Redis failure는 storage replay candidate로 분류
+- control dispatch failure는 control replay candidate로 분류
+- short-window duplicate suppression으로 즉시 중복 telemetry를 완화
+
+현재 노출되는 대표 메트릭:
+- `iot_ingestion_pipeline_overall_success_total`
+- `iot_ingestion_pipeline_core_success_total`
+- `iot_ingestion_processing_failure_total`
+- `iot_ingestion_inflight`
+- `iot_downlink_command_sent_total`
+- `iot_downlink_command_acked_total`
+- `iot_downlink_command_expired_total`
+
+관련 문서:
+- [Observability](docs/observability.md)
+- [Operations Runbook](docs/operations-runbook.md)
+
+## Load Test Notes
+이 프로젝트는 MQTT simulator 기반 부하 테스트와 결과 집계 스크립트를 포함합니다.
+
+현재까지 확인한 내용:
+- 초기 baseline 기준 로컬 환경에서 2000 동시 연결까지 안정적으로 검증
+- distributed simulator + HiveMQ path를 통해 더 높은 연결 수까지 비교 검증
+- strict 고부하 재검증에서는 local single-host WSL 환경의 CPU / memory / disk saturation이 병목으로 드러남
+
+중요한 해석:
+- connection success와 business pipeline success는 별개로 봐야 합니다.
+- local 환경 수치는 절대 성능 수치라기보다 병목과 개선 방향을 확인하기 위한 자료로 사용합니다.
+
+관련 문서:
+- [Load Test Results](docs/load-test-results.md)
+- [Load Test Scenarios](docs/load-test-scenarios.md)
+
+## Run Locally
+인프라 실행:
+```bash
+docker compose up -d
+```
+
+애플리케이션 실행:
+```bash
+./gradlew bootRun
+```
+
+테스트 실행:
+```bash
+./gradlew test
+```
+
+주요 확인 경로:
+- API: `http://localhost:8080/swagger-ui.html`
+- Actuator Health: `http://localhost:8080/actuator/health`
+- Prometheus: `http://localhost:9090`
+- Grafana: `http://localhost:3000`
+
+## Document Map
+- [Device API](docs/device-api.md)
+- [Swagger Guide](docs/swagger.md)
+- [Ingestion ADR](docs/adr/0001-ingestion-architecture.md)
+- [Observability](docs/observability.md)
+- [Operations Runbook](docs/operations-runbook.md)
+- [Load Test Results](docs/load-test-results.md)
+- [Load Test Scenarios](docs/load-test-scenarios.md)
+- [Refactoring Roadmap](docs/refactoring-roadmap.md)
+
+## Current Limits
+- duplicate suppression은 best-effort in-memory 정책입니다.
+- persistent DLQ / replay worker는 아직 없습니다.
+- queue/backpressure는 후속 단계입니다.
+- 고부하 strict 검증은 local single-host 환경 한계의 영향을 크게 받습니다.
+
+## Next Steps
+- persistent DLQ 및 replay flow 도입
+- queue/backpressure 기반 ingestion decoupling 검토
+- service test 구조 추가 분리
+- 운영 환경 기준 성능/복구 검증 강화

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,4 +1,4 @@
-# Observability Baseline (Phase 6)
+# Observability Guide
 
 ## Purpose
 - 운영 지표를 표준 endpoint로 노출한다.
@@ -48,7 +48,7 @@ curl -s http://localhost:8080/actuator/prometheus | rg "^iot\\."
 - `application`: `${spring.application.name}`
 - `env`: `${APP_ENV:local}`
 
-## Phase 2 Notes
+## Ingestion Notes
 - MQTT inbound channel은 executor 기반으로 분리되어 broker 수신 스레드와 downstream 처리 스레드를 느슨하게 분리한다.
 - business success 지표는 아래 두 축으로 본다.
   - overall pipeline success: parse 이후 Influx + Redis가 모두 성공한 건수
@@ -56,7 +56,7 @@ curl -s http://localhost:8080/actuator/prometheus | rg "^iot\\."
 - `strict` 모드는 Influx write path를 포함한 전체 경로 검증용이다.
 - `bypass` 모드는 Influx 압력을 제외하고 parse + Redis + control path를 검증하기 위한 모드다.
 
-## Grafana (Phase 7)
+## Grafana
 - Dashboard JSON:
   - `docs/grafana-observability-dashboard.json`
 - Runbook:

--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -1,4 +1,4 @@
-# Operations Runbook (Phase 7)
+# Operations Runbook
 
 ## Purpose
 - Grafana 대시보드를 기준으로 ingestion/downlink 이상 징후를 빠르게 분류하고 대응한다.
@@ -98,5 +98,6 @@
 - duplicate dropped/s: 평시 대비 급증 시 broker/network duplicate 여부 확인
 
 ## Related Docs
+- `README.md`
 - `docs/observability.md`
 - `docs/device-api.md`

--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -20,3 +20,4 @@
 ## Notes
 - Actuator endpoint는 `device-api` 그룹에 포함되지 않는다.
 - 실제 데이터 검증은 `docs/device-api.md`와 함께 사용한다.
+- 프로젝트 개요와 실행 흐름은 루트 `README.md`를 기준으로 확인한다.


### PR DESCRIPTION

  ## What Changed
  - 루트 `README.md`를 새로 작성
  - 프로젝트 개요, 기술 스택, 아키텍처, 핵심 기능, API 요약, reliability/observability, 부하 테스트 해석, 실행 방법, 문서 맵, 한
  계/다음 단계 정리
  - `docs/observability.md` 제목/섹션명을 현재 구조에 맞게 정리
  - `docs/operations-runbook.md`에 README 기준 진입점을 반영
  - `docs/swagger.md`에 README 참조 안내 추가

  ## Why
  - 개별 문서는 존재했지만 저장소 첫 화면만으로 프로젝트 목적과 강점을 파악하기 어려웠음
  - README를 중심으로 핵심 문서를 연결해 프로젝트 설명 흐름을 정리할 필요가 있었음
  - 구현 세부사항을 모두 나열하기보다, 현재 시스템이 무엇을 하고 어디까지 구현됐는지를 빠르게 이해할 수 있도록 정리함

  ## How To Verify
  - `README.md`만 읽고 프로젝트 개요, 아키텍처, 핵심 기능, 한계와 다음 단계를 설명할 수 있는지 확인
  - README에 연결된 문서 링크가 유효한지 확인
  - `docs/observability.md`, `docs/operations-runbook.md`, `docs/swagger.md`의 설명이 README와 충돌하지 않는지 확인

  ## Risks / Limits
  - 성능 관련 수치는 local environment 한계를 전제로 해석해야 함
  - README는 핵심 흐름 중심으로 압축했기 때문에 세부 구현 근거는 각 `docs/` 문서를 함께 봐야 함

  ## Next Step
  - 필요 시 `docs/device-api.md`, `docs/load-test-results.md`까지 README 서술 톤에 맞춰 추가 정리
  - 최종 제출 전 README 문장 톤과 링크를 한 번 더 점검
 closed #51 