### PR TITLE
techdebt: ingestion 성능 계측 추가 및 async 파이프라인 비교 결과 문서화

### DIFF
--- a/docs/load-test-results.md
+++ b/docs/load-test-results.md
@@ -176,3 +176,115 @@ Use the same split-table schema above for PR2 rows, with `Influx Bypass` and `Bu
   - `inflight`
   - ingestion processing latency timer
 - Re-run the 5k HiveMQ validation after this change and append strict/bypass comparison rows with the updated metric set.
+
+## Phase 2 Direct vs Executor (Bypass Mode)
+
+### Objective
+- Compare `direct` and `executor` channel modes under the same bypass-mode load.
+- Isolate parse + Redis + control path from Influx write pressure.
+
+### Test Conditions
+- Backend config:
+  - `ingestion.influx.write-mode=bypass`
+  - `ingestion.channel.mode=direct|executor`
+- Simulator:
+  - `SIM_TASK=mqttLoadTestHive`
+  - `messages-per-second=1`
+  - `duration-seconds=60`
+  - `qos=1`
+- Measurement focus:
+  - connection throughput
+  - business `core_pipeline_success_rate`
+  - executor queue wait presence
+
+### Commands
+```bash
+# direct + bypass
+SIM_TASK=mqttLoadTestHive RUN_ID="direct-bypass-1000-$(date +%Y%m%d-%H%M%S)" MAX_ATTEMPTS=1 PART_TIMEOUT_SECONDS=300 REQUIRE_BUSINESS_SUMMARY=1 ./scripts/loadtest/run-distributed.sh 1000 2 120 1 60 1
+SIM_TASK=mqttLoadTestHive RUN_ID="direct-bypass-2000-$(date +%Y%m%d-%H%M%S)" MAX_ATTEMPTS=1 PART_TIMEOUT_SECONDS=360 REQUIRE_BUSINESS_SUMMARY=1 ./scripts/loadtest/run-distributed.sh 2000 3 120 1 60 1
+SIM_TASK=mqttLoadTestHive RUN_ID="direct-bypass-3000-$(date +%Y%m%d-%H%M%S)" MAX_ATTEMPTS=1 PART_TIMEOUT_SECONDS=420 REQUIRE_BUSINESS_SUMMARY=1 ./scripts/loadtest/run-distributed.sh 3000 4 120 1 60 1
+
+# executor + bypass
+SIM_TASK=mqttLoadTestHive RUN_ID="executor-bypass-1000-$(date +%Y%m%d-%H%M%S)" MAX_ATTEMPTS=1 PART_TIMEOUT_SECONDS=300 REQUIRE_BUSINESS_SUMMARY=1 ./scripts/loadtest/run-distributed.sh 1000 2 120 1 60 1
+SIM_TASK=mqttLoadTestHive RUN_ID="executor-bypass-2000-$(date +%Y%m%d-%H%M%S)" MAX_ATTEMPTS=1 PART_TIMEOUT_SECONDS=360 REQUIRE_BUSINESS_SUMMARY=1 ./scripts/loadtest/run-distributed.sh 2000 3 120 1 60 1
+SIM_TASK=mqttLoadTestHive RUN_ID="executor-bypass-3000-$(date +%Y%m%d-%H%M%S)" MAX_ATTEMPTS=1 PART_TIMEOUT_SECONDS=420 REQUIRE_BUSINESS_SUMMARY=1 ./scripts/loadtest/run-distributed.sh 3000 4 120 1 60 1
+```
+
+### Results
+| Mode | Connections | Run ID | Published | Failed | Throughput (msg/s) | Business recv | Core pipeline success | Core success(%) | Notes |
+|---|---:|---|---:|---:|---:|---:|---:|---:|---|
+| direct | 1000 | `direct-bypass-1000-20260323-013750` | `61000` | `0` | `1016.66` | `14532` | `12983` | `89.34` | bypass mode |
+| direct | 2000 | `direct-bypass-2000-20260323-014108` | `122000` | `0` | `2033.34` | `7915` | `7084` | `89.50` | bypass mode |
+| direct | 3000 | `direct-bypass-3000-retry-20260323-014826` | `183000` | `0` | `3050.00` | `8249` | `7633` | `92.53` | bypass mode |
+| executor | 1000 | `executor-bypass-1000-20260323-020032` | `60500` | `0` | `1008.33` | `10831` | `10572` | `97.61` | queue wait measured |
+| executor | 2000 | `executor-bypass-2000-20260323-020305` | `122000` | `0` | `2033.34` | `5849` | `5777` | `98.77` | queue wait measured |
+| executor | 3000 | `executor-bypass-3000-20260323-020536` | `183000` | `0` | `3050.00` | `5371` | `5349` | `99.59` | queue wait measured |
+
+### Comparison Summary
+| Connections | Direct core success(%) | Executor core success(%) | Improvement (%p) |
+|---:|---:|---:|---:|
+| 1000 | `89.34` | `97.61` | `+8.27` |
+| 2000 | `89.50` | `98.77` | `+9.27` |
+| 3000 | `92.53` | `99.59` | `+7.06` |
+
+### Interpretation
+- Connection-level throughput stayed stable across both modes up to `3050 msg/s`.
+- In bypass mode, `executor` consistently improved `core_pipeline_success_rate` over `direct`.
+- The measured gain range was `+7.06%p` to `+9.27%p`.
+- `executor` mode produced observable queue wait metrics, which confirms that the broker receive thread and downstream processing were decoupled.
+- `executor_rejected_total` was observed during the executor test session, so saturation guard behavior should still be tracked in follow-up runs.
+
+### Measurement Notes
+- In bypass mode, `overall pipeline success` remains `0` by formula because Influx actual write success is intentionally excluded.
+- For bypass-mode comparisons, use `core_pipeline_success_rate` as the primary business metric.
+- Source artifacts:
+  - `docs/loadtest-runs/direct-bypass-1000-20260323-013750/attempt-1/*`
+  - `docs/loadtest-runs/direct-bypass-2000-20260323-014108/attempt-1/*`
+  - `docs/loadtest-runs/direct-bypass-3000-retry-20260323-014826/attempt-1/*`
+  - `docs/loadtest-runs/executor-bypass-1000-20260323-020032/attempt-1/*`
+  - `docs/loadtest-runs/executor-bypass-2000-20260323-020305/attempt-1/*`
+  - `docs/loadtest-runs/executor-bypass-3000-20260323-020536/attempt-1/*`
+
+## Phase 2 Executor Strict Validation
+
+### Objective
+- Validate the full ingestion path with Influx write enabled after bypass-mode comparison.
+- Confirm whether the executor-based path remains stable when actual Influx persistence is included.
+
+### Preconditions
+- `ingestion.channel.mode=executor`
+- `ingestion.influx.write-mode=strict`
+- Influx direct write probe succeeded with `HTTP 204`
+
+Direct write probe:
+```bash
+curl -i -XPOST "http://localhost:8086/api/v2/write?org=myorg&bucket=sousvide_bucket&precision=s" \
+  -H "Authorization: Token my-super-secret-auth-token" \
+  --data-raw "strict_probe,deviceId=SV-TEST temp=60.5"
+```
+
+### Commands
+```bash
+SIM_TASK=mqttLoadTestHive RUN_ID="executor-strict-1000-clean-$(date +%Y%m%d-%H%M%S)" MAX_ATTEMPTS=1 PART_TIMEOUT_SECONDS=300 ./scripts/loadtest/run-distributed.sh 1000 2 120 1 60 1
+SIM_TASK=mqttLoadTestHive RUN_ID="executor-strict-2000-clean-retry-$(date +%Y%m%d-%H%M%S)" MAX_ATTEMPTS=1 PART_TIMEOUT_SECONDS=360 ./scripts/loadtest/run-distributed.sh 2000 3 120 1 60 1
+SIM_TASK=mqttLoadTestHive RUN_ID="executor-strict-3000-clean-retry-$(date +%Y%m%d-%H%M%S)" MAX_ATTEMPTS=1 PART_TIMEOUT_SECONDS=420 ./scripts/loadtest/run-distributed.sh 3000 4 120 1 60 1
+```
+
+### Results
+| Mode | Connections | Run ID | Published | Failed | Throughput (msg/s) | Business recv | Influx success | Influx failure | Overall pipeline success | Overall success(%) | Notes |
+|---|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| executor + strict | 1000 | `executor-strict-1000-clean-20260323-022447` | `61000` | `0` | `1016.66` | `5888` | `5776` | `0` | `5776` | `98.10` | manual business summary generation |
+| executor + strict | 2000 | `executor-strict-2000-clean-retry-20260323-023138` | `122000` | `0` | `2033.34` | `5208` | `5204` | `0` | `5204` | `99.92` | manual business summary generation |
+| executor + strict | 3000 | `executor-strict-3000-clean-retry-20260323-023509` | `183000` | `0` | `3050.00` | `5346` | `5323` | `0` | `5323` | `99.57` | manual business summary generation |
+
+### Interpretation
+- After restoring valid Influx authorization, the strict path completed with `0` Influx write failures in all measured runs.
+- Executor-based ingestion remained stable up to `3050 msg/s` connection throughput with `99.57%` to `99.92%` overall pipeline success in the measured strict runs.
+- This confirms that the executor-based channel not only improves the bypass-mode core path, but also sustains high success rates when actual Influx persistence is included.
+
+### Strict Validation Notes
+- For the strict reruns, `business-summary.json` for the later runs was generated by copying the completed `backend.log` into the attempt directory and running `scripts/loadtest/summarize-ingestion-metrics.sh` manually.
+- Source artifacts:
+  - `docs/loadtest-runs/executor-strict-1000-clean-20260323-022447/attempt-1/*`
+  - `docs/loadtest-runs/executor-strict-2000-clean-retry-20260323-023138/attempt-1/*`
+  - `docs/loadtest-runs/executor-strict-3000-clean-retry-20260323-023509/attempt-1/*`

--- a/docs/loadtest-runs/20260323-011610/attempt-1/connection-summary.json
+++ b/docs/loadtest-runs/20260323-011610/attempt-1/connection-summary.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "20260323-011610",
+  "attempt": "1",
+  "parts": 2,
+  "published_total": 61000,
+  "failed_total": 0,
+  "attempted_total": 61000,
+  "success_rate": 1.0000,
+  "success_rate_pct": 100.00,
+  "throughput_total_msg_per_sec": 1016.66,
+  "success_rate_formula": "published_total / (published_total + failed_total)"
+}

--- a/docs/loadtest-runs/20260323-011755/attempt-1/connection-summary.json
+++ b/docs/loadtest-runs/20260323-011755/attempt-1/connection-summary.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "20260323-011755",
+  "attempt": "1",
+  "parts": 3,
+  "published_total": 122000,
+  "failed_total": 0,
+  "attempted_total": 122000,
+  "success_rate": 1.0000,
+  "success_rate_pct": 100.00,
+  "throughput_total_msg_per_sec": 2033.34,
+  "success_rate_formula": "published_total / (published_total + failed_total)"
+}

--- a/docs/loadtest-runs/20260323-012805/attempt-1/connection-summary.json
+++ b/docs/loadtest-runs/20260323-012805/attempt-1/connection-summary.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "20260323-012805",
+  "attempt": "1",
+  "parts": 2,
+  "published_total": 61000,
+  "failed_total": 0,
+  "attempted_total": 61000,
+  "success_rate": 1.0000,
+  "success_rate_pct": 100.00,
+  "throughput_total_msg_per_sec": 1016.66,
+  "success_rate_formula": "published_total / (published_total + failed_total)"
+}

--- a/docs/loadtest-runs/direct-bypass-1000-20260323-013750/attempt-1/business-summary.json
+++ b/docs/loadtest-runs/direct-bypass-1000-20260323-013750/attempt-1/business-summary.json
@@ -1,0 +1,22 @@
+{
+  "run_id": "direct-bypass-1000-20260323-013750",
+  "attempt": "1",
+  "recv_total": 14532,
+  "parse_ok_total": 12983,
+  "parse_fail_total": 0,
+  "influx_ok_total": 0,
+  "influx_fail_total": 0,
+  "influx_bypass_total": 12983,
+  "redis_ok_total": 12983,
+  "redis_fail_total": 0,
+  "pipeline_success_total": 0,
+  "pipeline_failure_total": 14532,
+  "pipeline_success_rate": 0.0000,
+  "pipeline_success_rate_pct": 0.00,
+  "pipeline_success_formula": "min(parse_ok_total, influx_ok_total, redis_ok_total) / recv_total",
+  "core_pipeline_success_total": 12983,
+  "core_pipeline_failure_total": 1549,
+  "core_pipeline_success_rate": 0.8934,
+  "core_pipeline_success_rate_pct": 89.34,
+  "core_pipeline_success_formula": "min(parse_ok_total, redis_ok_total) / recv_total"
+}

--- a/docs/loadtest-runs/direct-bypass-1000-20260323-013750/attempt-1/connection-summary.json
+++ b/docs/loadtest-runs/direct-bypass-1000-20260323-013750/attempt-1/connection-summary.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "direct-bypass-1000-20260323-013750",
+  "attempt": "1",
+  "parts": 2,
+  "published_total": 61000,
+  "failed_total": 0,
+  "attempted_total": 61000,
+  "success_rate": 1.0000,
+  "success_rate_pct": 100.00,
+  "throughput_total_msg_per_sec": 1016.66,
+  "success_rate_formula": "published_total / (published_total + failed_total)"
+}

--- a/docs/loadtest-runs/direct-bypass-2000-20260323-014108/attempt-1/business-summary.json
+++ b/docs/loadtest-runs/direct-bypass-2000-20260323-014108/attempt-1/business-summary.json
@@ -1,0 +1,22 @@
+{
+  "run_id": "direct-bypass-2000-20260323-014108",
+  "attempt": "1",
+  "recv_total": 7915,
+  "parse_ok_total": 7084,
+  "parse_fail_total": 0,
+  "influx_ok_total": 0,
+  "influx_fail_total": 0,
+  "influx_bypass_total": 7084,
+  "redis_ok_total": 7084,
+  "redis_fail_total": 0,
+  "pipeline_success_total": 0,
+  "pipeline_failure_total": 7915,
+  "pipeline_success_rate": 0.0000,
+  "pipeline_success_rate_pct": 0.00,
+  "pipeline_success_formula": "min(parse_ok_total, influx_ok_total, redis_ok_total) / recv_total",
+  "core_pipeline_success_total": 7084,
+  "core_pipeline_failure_total": 831,
+  "core_pipeline_success_rate": 0.8950,
+  "core_pipeline_success_rate_pct": 89.50,
+  "core_pipeline_success_formula": "min(parse_ok_total, redis_ok_total) / recv_total"
+}

--- a/docs/loadtest-runs/direct-bypass-2000-20260323-014108/attempt-1/connection-summary.json
+++ b/docs/loadtest-runs/direct-bypass-2000-20260323-014108/attempt-1/connection-summary.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "direct-bypass-2000-20260323-014108",
+  "attempt": "1",
+  "parts": 3,
+  "published_total": 122000,
+  "failed_total": 0,
+  "attempted_total": 122000,
+  "success_rate": 1.0000,
+  "success_rate_pct": 100.00,
+  "throughput_total_msg_per_sec": 2033.34,
+  "success_rate_formula": "published_total / (published_total + failed_total)"
+}

--- a/docs/loadtest-runs/direct-bypass-3000-retry-20260323-014826/attempt-1/business-summary.json
+++ b/docs/loadtest-runs/direct-bypass-3000-retry-20260323-014826/attempt-1/business-summary.json
@@ -1,0 +1,22 @@
+{
+  "run_id": "direct-bypass-3000-retry-20260323-014826",
+  "attempt": "1",
+  "recv_total": 8249,
+  "parse_ok_total": 7634,
+  "parse_fail_total": 0,
+  "influx_ok_total": 0,
+  "influx_fail_total": 0,
+  "influx_bypass_total": 7634,
+  "redis_ok_total": 7633,
+  "redis_fail_total": 0,
+  "pipeline_success_total": 0,
+  "pipeline_failure_total": 8249,
+  "pipeline_success_rate": 0.0000,
+  "pipeline_success_rate_pct": 0.00,
+  "pipeline_success_formula": "min(parse_ok_total, influx_ok_total, redis_ok_total) / recv_total",
+  "core_pipeline_success_total": 7633,
+  "core_pipeline_failure_total": 616,
+  "core_pipeline_success_rate": 0.9253,
+  "core_pipeline_success_rate_pct": 92.53,
+  "core_pipeline_success_formula": "min(parse_ok_total, redis_ok_total) / recv_total"
+}

--- a/docs/loadtest-runs/direct-bypass-3000-retry-20260323-014826/attempt-1/connection-summary.json
+++ b/docs/loadtest-runs/direct-bypass-3000-retry-20260323-014826/attempt-1/connection-summary.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "direct-bypass-3000-retry-20260323-014826",
+  "attempt": "1",
+  "parts": 4,
+  "published_total": 183000,
+  "failed_total": 0,
+  "attempted_total": 183000,
+  "success_rate": 1.0000,
+  "success_rate_pct": 100.00,
+  "throughput_total_msg_per_sec": 3050.00,
+  "success_rate_formula": "published_total / (published_total + failed_total)"
+}

--- a/docs/loadtest-runs/executor-bypass-1000-20260323-015327/attempt-1/business-summary.json
+++ b/docs/loadtest-runs/executor-bypass-1000-20260323-015327/attempt-1/business-summary.json
@@ -1,0 +1,22 @@
+{
+  "run_id": "executor-bypass-1000-20260323-015327",
+  "attempt": "1",
+  "recv_total": 10769,
+  "parse_ok_total": 10512,
+  "parse_fail_total": 0,
+  "influx_ok_total": 0,
+  "influx_fail_total": 0,
+  "influx_bypass_total": 10512,
+  "redis_ok_total": 10512,
+  "redis_fail_total": 0,
+  "pipeline_success_total": 0,
+  "pipeline_failure_total": 10769,
+  "pipeline_success_rate": 0.0000,
+  "pipeline_success_rate_pct": 0.00,
+  "pipeline_success_formula": "min(parse_ok_total, influx_ok_total, redis_ok_total) / recv_total",
+  "core_pipeline_success_total": 10512,
+  "core_pipeline_failure_total": 257,
+  "core_pipeline_success_rate": 0.9761,
+  "core_pipeline_success_rate_pct": 97.61,
+  "core_pipeline_success_formula": "min(parse_ok_total, redis_ok_total) / recv_total"
+}

--- a/docs/loadtest-runs/executor-bypass-1000-20260323-015327/attempt-1/connection-summary.json
+++ b/docs/loadtest-runs/executor-bypass-1000-20260323-015327/attempt-1/connection-summary.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "executor-bypass-1000-20260323-015327",
+  "attempt": "1",
+  "parts": 2,
+  "published_total": 61000,
+  "failed_total": 0,
+  "attempted_total": 61000,
+  "success_rate": 1.0000,
+  "success_rate_pct": 100.00,
+  "throughput_total_msg_per_sec": 1016.66,
+  "success_rate_formula": "published_total / (published_total + failed_total)"
+}

--- a/docs/loadtest-runs/executor-bypass-1000-20260323-020032/attempt-1/business-summary.json
+++ b/docs/loadtest-runs/executor-bypass-1000-20260323-020032/attempt-1/business-summary.json
@@ -1,0 +1,22 @@
+{
+  "run_id": "executor-bypass-1000-20260323-020032",
+  "attempt": "1",
+  "recv_total": 10831,
+  "parse_ok_total": 10572,
+  "parse_fail_total": 0,
+  "influx_ok_total": 0,
+  "influx_fail_total": 0,
+  "influx_bypass_total": 10572,
+  "redis_ok_total": 10572,
+  "redis_fail_total": 0,
+  "pipeline_success_total": 0,
+  "pipeline_failure_total": 10831,
+  "pipeline_success_rate": 0.0000,
+  "pipeline_success_rate_pct": 0.00,
+  "pipeline_success_formula": "min(parse_ok_total, influx_ok_total, redis_ok_total) / recv_total",
+  "core_pipeline_success_total": 10572,
+  "core_pipeline_failure_total": 259,
+  "core_pipeline_success_rate": 0.9761,
+  "core_pipeline_success_rate_pct": 97.61,
+  "core_pipeline_success_formula": "min(parse_ok_total, redis_ok_total) / recv_total"
+}

--- a/docs/loadtest-runs/executor-bypass-1000-20260323-020032/attempt-1/connection-summary.json
+++ b/docs/loadtest-runs/executor-bypass-1000-20260323-020032/attempt-1/connection-summary.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "executor-bypass-1000-20260323-020032",
+  "attempt": "1",
+  "parts": 2,
+  "published_total": 60500,
+  "failed_total": 0,
+  "attempted_total": 60500,
+  "success_rate": 1.0000,
+  "success_rate_pct": 100.00,
+  "throughput_total_msg_per_sec": 1008.33,
+  "success_rate_formula": "published_total / (published_total + failed_total)"
+}

--- a/docs/loadtest-runs/executor-bypass-2000-20260323-020305/attempt-1/business-summary.json
+++ b/docs/loadtest-runs/executor-bypass-2000-20260323-020305/attempt-1/business-summary.json
@@ -1,0 +1,22 @@
+{
+  "run_id": "executor-bypass-2000-20260323-020305",
+  "attempt": "1",
+  "recv_total": 5849,
+  "parse_ok_total": 5777,
+  "parse_fail_total": 0,
+  "influx_ok_total": 0,
+  "influx_fail_total": 0,
+  "influx_bypass_total": 5777,
+  "redis_ok_total": 5777,
+  "redis_fail_total": 0,
+  "pipeline_success_total": 0,
+  "pipeline_failure_total": 5849,
+  "pipeline_success_rate": 0.0000,
+  "pipeline_success_rate_pct": 0.00,
+  "pipeline_success_formula": "min(parse_ok_total, influx_ok_total, redis_ok_total) / recv_total",
+  "core_pipeline_success_total": 5777,
+  "core_pipeline_failure_total": 72,
+  "core_pipeline_success_rate": 0.9877,
+  "core_pipeline_success_rate_pct": 98.77,
+  "core_pipeline_success_formula": "min(parse_ok_total, redis_ok_total) / recv_total"
+}

--- a/docs/loadtest-runs/executor-bypass-2000-20260323-020305/attempt-1/connection-summary.json
+++ b/docs/loadtest-runs/executor-bypass-2000-20260323-020305/attempt-1/connection-summary.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "executor-bypass-2000-20260323-020305",
+  "attempt": "1",
+  "parts": 3,
+  "published_total": 122000,
+  "failed_total": 0,
+  "attempted_total": 122000,
+  "success_rate": 1.0000,
+  "success_rate_pct": 100.00,
+  "throughput_total_msg_per_sec": 2033.34,
+  "success_rate_formula": "published_total / (published_total + failed_total)"
+}

--- a/docs/loadtest-runs/executor-bypass-3000-20260323-020536/attempt-1/business-summary.json
+++ b/docs/loadtest-runs/executor-bypass-3000-20260323-020536/attempt-1/business-summary.json
@@ -1,0 +1,22 @@
+{
+  "run_id": "executor-bypass-3000-20260323-020536",
+  "attempt": "1",
+  "recv_total": 5371,
+  "parse_ok_total": 5349,
+  "parse_fail_total": 0,
+  "influx_ok_total": 0,
+  "influx_fail_total": 0,
+  "influx_bypass_total": 5349,
+  "redis_ok_total": 5349,
+  "redis_fail_total": 0,
+  "pipeline_success_total": 0,
+  "pipeline_failure_total": 5371,
+  "pipeline_success_rate": 0.0000,
+  "pipeline_success_rate_pct": 0.00,
+  "pipeline_success_formula": "min(parse_ok_total, influx_ok_total, redis_ok_total) / recv_total",
+  "core_pipeline_success_total": 5349,
+  "core_pipeline_failure_total": 22,
+  "core_pipeline_success_rate": 0.9959,
+  "core_pipeline_success_rate_pct": 99.59,
+  "core_pipeline_success_formula": "min(parse_ok_total, redis_ok_total) / recv_total"
+}

--- a/docs/loadtest-runs/executor-bypass-3000-20260323-020536/attempt-1/connection-summary.json
+++ b/docs/loadtest-runs/executor-bypass-3000-20260323-020536/attempt-1/connection-summary.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "executor-bypass-3000-20260323-020536",
+  "attempt": "1",
+  "parts": 4,
+  "published_total": 183000,
+  "failed_total": 0,
+  "attempted_total": 183000,
+  "success_rate": 1.0000,
+  "success_rate_pct": 100.00,
+  "throughput_total_msg_per_sec": 3050.00,
+  "success_rate_formula": "published_total / (published_total + failed_total)"
+}

--- a/docs/loadtest-runs/executor-strict-1000-20260323-021842/attempt-1/business-summary.json
+++ b/docs/loadtest-runs/executor-strict-1000-20260323-021842/attempt-1/business-summary.json
@@ -1,0 +1,22 @@
+{
+  "run_id": "executor-strict-1000-20260323-021842",
+  "attempt": "1",
+  "recv_total": 5448,
+  "parse_ok_total": 5447,
+  "parse_fail_total": 0,
+  "influx_ok_total": 5447,
+  "influx_fail_total": 0,
+  "influx_bypass_total": 0,
+  "redis_ok_total": 5447,
+  "redis_fail_total": 0,
+  "pipeline_success_total": 5447,
+  "pipeline_failure_total": 1,
+  "pipeline_success_rate": 0.9998,
+  "pipeline_success_rate_pct": 99.98,
+  "pipeline_success_formula": "min(parse_ok_total, influx_ok_total, redis_ok_total) / recv_total",
+  "core_pipeline_success_total": 5447,
+  "core_pipeline_failure_total": 1,
+  "core_pipeline_success_rate": 0.9998,
+  "core_pipeline_success_rate_pct": 99.98,
+  "core_pipeline_success_formula": "min(parse_ok_total, redis_ok_total) / recv_total"
+}

--- a/docs/loadtest-runs/executor-strict-1000-20260323-021842/attempt-1/connection-summary.json
+++ b/docs/loadtest-runs/executor-strict-1000-20260323-021842/attempt-1/connection-summary.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "executor-strict-1000-20260323-021842",
+  "attempt": "1",
+  "parts": 2,
+  "published_total": 61000,
+  "failed_total": 0,
+  "attempted_total": 61000,
+  "success_rate": 1.0000,
+  "success_rate_pct": 100.00,
+  "throughput_total_msg_per_sec": 1016.66,
+  "success_rate_formula": "published_total / (published_total + failed_total)"
+}

--- a/docs/loadtest-runs/executor-strict-1000-clean-20260323-022447/attempt-1/business-summary.json
+++ b/docs/loadtest-runs/executor-strict-1000-clean-20260323-022447/attempt-1/business-summary.json
@@ -1,0 +1,22 @@
+{
+  "run_id": "executor-strict-1000-clean-20260323-022447",
+  "attempt": "1",
+  "recv_total": 5888,
+  "parse_ok_total": 5776,
+  "parse_fail_total": 0,
+  "influx_ok_total": 5776,
+  "influx_fail_total": 0,
+  "influx_bypass_total": 0,
+  "redis_ok_total": 5776,
+  "redis_fail_total": 0,
+  "pipeline_success_total": 5776,
+  "pipeline_failure_total": 112,
+  "pipeline_success_rate": 0.9810,
+  "pipeline_success_rate_pct": 98.10,
+  "pipeline_success_formula": "min(parse_ok_total, influx_ok_total, redis_ok_total) / recv_total",
+  "core_pipeline_success_total": 5776,
+  "core_pipeline_failure_total": 112,
+  "core_pipeline_success_rate": 0.9810,
+  "core_pipeline_success_rate_pct": 98.10,
+  "core_pipeline_success_formula": "min(parse_ok_total, redis_ok_total) / recv_total"
+}

--- a/docs/loadtest-runs/executor-strict-1000-clean-20260323-022447/attempt-1/connection-summary.json
+++ b/docs/loadtest-runs/executor-strict-1000-clean-20260323-022447/attempt-1/connection-summary.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "executor-strict-1000-clean-20260323-022447",
+  "attempt": "1",
+  "parts": 2,
+  "published_total": 61000,
+  "failed_total": 0,
+  "attempted_total": 61000,
+  "success_rate": 1.0000,
+  "success_rate_pct": 100.00,
+  "throughput_total_msg_per_sec": 1016.66,
+  "success_rate_formula": "published_total / (published_total + failed_total)"
+}

--- a/docs/loadtest-runs/executor-strict-2000-20260323-022125/attempt-1/business-summary.json
+++ b/docs/loadtest-runs/executor-strict-2000-20260323-022125/attempt-1/business-summary.json
@@ -1,0 +1,22 @@
+{
+  "run_id": "executor-strict-2000-20260323-022125",
+  "attempt": "1",
+  "recv_total": 5448,
+  "parse_ok_total": 5447,
+  "parse_fail_total": 0,
+  "influx_ok_total": 5447,
+  "influx_fail_total": 0,
+  "influx_bypass_total": 0,
+  "redis_ok_total": 5447,
+  "redis_fail_total": 0,
+  "pipeline_success_total": 5447,
+  "pipeline_failure_total": 1,
+  "pipeline_success_rate": 0.9998,
+  "pipeline_success_rate_pct": 99.98,
+  "pipeline_success_formula": "min(parse_ok_total, influx_ok_total, redis_ok_total) / recv_total",
+  "core_pipeline_success_total": 5447,
+  "core_pipeline_failure_total": 1,
+  "core_pipeline_success_rate": 0.9998,
+  "core_pipeline_success_rate_pct": 99.98,
+  "core_pipeline_success_formula": "min(parse_ok_total, redis_ok_total) / recv_total"
+}

--- a/docs/loadtest-runs/executor-strict-2000-20260323-022125/attempt-1/connection-summary.json
+++ b/docs/loadtest-runs/executor-strict-2000-20260323-022125/attempt-1/connection-summary.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "executor-strict-2000-20260323-022125",
+  "attempt": "1",
+  "parts": 3,
+  "published_total": 122000,
+  "failed_total": 0,
+  "attempted_total": 122000,
+  "success_rate": 1.0000,
+  "success_rate_pct": 100.00,
+  "throughput_total_msg_per_sec": 2033.34,
+  "success_rate_formula": "published_total / (published_total + failed_total)"
+}

--- a/docs/loadtest-runs/executor-strict-2000-clean-20260323-022719/attempt-1/connection-summary.json
+++ b/docs/loadtest-runs/executor-strict-2000-clean-20260323-022719/attempt-1/connection-summary.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "executor-strict-2000-clean-20260323-022719",
+  "attempt": "1",
+  "parts": 3,
+  "published_total": 122000,
+  "failed_total": 0,
+  "attempted_total": 122000,
+  "success_rate": 1.0000,
+  "success_rate_pct": 100.00,
+  "throughput_total_msg_per_sec": 2033.34,
+  "success_rate_formula": "published_total / (published_total + failed_total)"
+}

--- a/docs/loadtest-runs/executor-strict-2000-clean-retry-20260323-023138/attempt-1/business-summary.json
+++ b/docs/loadtest-runs/executor-strict-2000-clean-retry-20260323-023138/attempt-1/business-summary.json
@@ -1,0 +1,22 @@
+{
+  "run_id": "executor-strict-2000-clean-retry-20260323-023138",
+  "attempt": "1",
+  "recv_total": 5208,
+  "parse_ok_total": 5204,
+  "parse_fail_total": 0,
+  "influx_ok_total": 5204,
+  "influx_fail_total": 0,
+  "influx_bypass_total": 0,
+  "redis_ok_total": 5204,
+  "redis_fail_total": 0,
+  "pipeline_success_total": 5204,
+  "pipeline_failure_total": 4,
+  "pipeline_success_rate": 0.9992,
+  "pipeline_success_rate_pct": 99.92,
+  "pipeline_success_formula": "min(parse_ok_total, influx_ok_total, redis_ok_total) / recv_total",
+  "core_pipeline_success_total": 5204,
+  "core_pipeline_failure_total": 4,
+  "core_pipeline_success_rate": 0.9992,
+  "core_pipeline_success_rate_pct": 99.92,
+  "core_pipeline_success_formula": "min(parse_ok_total, redis_ok_total) / recv_total"
+}

--- a/docs/loadtest-runs/executor-strict-2000-clean-retry-20260323-023138/attempt-1/connection-summary.json
+++ b/docs/loadtest-runs/executor-strict-2000-clean-retry-20260323-023138/attempt-1/connection-summary.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "executor-strict-2000-clean-retry-20260323-023138",
+  "attempt": "1",
+  "parts": 3,
+  "published_total": 122000,
+  "failed_total": 0,
+  "attempted_total": 122000,
+  "success_rate": 1.0000,
+  "success_rate_pct": 100.00,
+  "throughput_total_msg_per_sec": 2033.34,
+  "success_rate_formula": "published_total / (published_total + failed_total)"
+}

--- a/docs/loadtest-runs/executor-strict-3000-clean-retry-20260323-023509/attempt-1/business-summary.json
+++ b/docs/loadtest-runs/executor-strict-3000-clean-retry-20260323-023509/attempt-1/business-summary.json
@@ -1,0 +1,22 @@
+{
+  "run_id": "executor-strict-3000-clean-retry-20260323-023509",
+  "attempt": "1",
+  "recv_total": 5346,
+  "parse_ok_total": 5323,
+  "parse_fail_total": 0,
+  "influx_ok_total": 5323,
+  "influx_fail_total": 0,
+  "influx_bypass_total": 0,
+  "redis_ok_total": 5323,
+  "redis_fail_total": 0,
+  "pipeline_success_total": 5323,
+  "pipeline_failure_total": 23,
+  "pipeline_success_rate": 0.9957,
+  "pipeline_success_rate_pct": 99.57,
+  "pipeline_success_formula": "min(parse_ok_total, influx_ok_total, redis_ok_total) / recv_total",
+  "core_pipeline_success_total": 5323,
+  "core_pipeline_failure_total": 23,
+  "core_pipeline_success_rate": 0.9957,
+  "core_pipeline_success_rate_pct": 99.57,
+  "core_pipeline_success_formula": "min(parse_ok_total, redis_ok_total) / recv_total"
+}

--- a/docs/loadtest-runs/executor-strict-3000-clean-retry-20260323-023509/attempt-1/connection-summary.json
+++ b/docs/loadtest-runs/executor-strict-3000-clean-retry-20260323-023509/attempt-1/connection-summary.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "executor-strict-3000-clean-retry-20260323-023509",
+  "attempt": "1",
+  "parts": 4,
+  "published_total": 183000,
+  "failed_total": 0,
+  "attempted_total": 183000,
+  "success_rate": 1.0000,
+  "success_rate_pct": 100.00,
+  "throughput_total_msg_per_sec": 3050.00,
+  "success_rate_formula": "published_total / (published_total + failed_total)"
+}

--- a/docs/loadtest-runs/manifest.json
+++ b/docs/loadtest-runs/manifest.json
@@ -1,11 +1,77 @@
 {
-  "generated_at": "2026-02-19T16:15:40+0900",
+  "generated_at": "2026-03-23T02:36:32+0900",
   "entries": [
     {
       "run_id": "dash-5k-20260219-161125",
       "attempt": "1",
       "connection_path": "docs/loadtest-runs/dash-5k-20260219-161125/attempt-1/connection-summary.json",
       "business_path": "docs/loadtest-runs/dash-5k-20260219-161125/attempt-1/business-summary.json"
+    },
+    {
+      "run_id": "direct-bypass-1000-20260323-013750",
+      "attempt": "1",
+      "connection_path": "docs/loadtest-runs/direct-bypass-1000-20260323-013750/attempt-1/connection-summary.json",
+      "business_path": "docs/loadtest-runs/direct-bypass-1000-20260323-013750/attempt-1/business-summary.json"
+    },
+    {
+      "run_id": "direct-bypass-2000-20260323-014108",
+      "attempt": "1",
+      "connection_path": "docs/loadtest-runs/direct-bypass-2000-20260323-014108/attempt-1/connection-summary.json",
+      "business_path": "docs/loadtest-runs/direct-bypass-2000-20260323-014108/attempt-1/business-summary.json"
+    },
+    {
+      "run_id": "direct-bypass-3000-retry-20260323-014826",
+      "attempt": "1",
+      "connection_path": "docs/loadtest-runs/direct-bypass-3000-retry-20260323-014826/attempt-1/connection-summary.json",
+      "business_path": "docs/loadtest-runs/direct-bypass-3000-retry-20260323-014826/attempt-1/business-summary.json"
+    },
+    {
+      "run_id": "executor-bypass-1000-20260323-015327",
+      "attempt": "1",
+      "connection_path": "docs/loadtest-runs/executor-bypass-1000-20260323-015327/attempt-1/connection-summary.json",
+      "business_path": "docs/loadtest-runs/executor-bypass-1000-20260323-015327/attempt-1/business-summary.json"
+    },
+    {
+      "run_id": "executor-bypass-1000-20260323-020032",
+      "attempt": "1",
+      "connection_path": "docs/loadtest-runs/executor-bypass-1000-20260323-020032/attempt-1/connection-summary.json",
+      "business_path": "docs/loadtest-runs/executor-bypass-1000-20260323-020032/attempt-1/business-summary.json"
+    },
+    {
+      "run_id": "executor-bypass-2000-20260323-020305",
+      "attempt": "1",
+      "connection_path": "docs/loadtest-runs/executor-bypass-2000-20260323-020305/attempt-1/connection-summary.json",
+      "business_path": "docs/loadtest-runs/executor-bypass-2000-20260323-020305/attempt-1/business-summary.json"
+    },
+    {
+      "run_id": "executor-bypass-3000-20260323-020536",
+      "attempt": "1",
+      "connection_path": "docs/loadtest-runs/executor-bypass-3000-20260323-020536/attempt-1/connection-summary.json",
+      "business_path": "docs/loadtest-runs/executor-bypass-3000-20260323-020536/attempt-1/business-summary.json"
+    },
+    {
+      "run_id": "executor-strict-1000-20260323-021842",
+      "attempt": "1",
+      "connection_path": "docs/loadtest-runs/executor-strict-1000-20260323-021842/attempt-1/connection-summary.json",
+      "business_path": "docs/loadtest-runs/executor-strict-1000-20260323-021842/attempt-1/business-summary.json"
+    },
+    {
+      "run_id": "executor-strict-1000-clean-20260323-022447",
+      "attempt": "1",
+      "connection_path": "docs/loadtest-runs/executor-strict-1000-clean-20260323-022447/attempt-1/connection-summary.json",
+      "business_path": "docs/loadtest-runs/executor-strict-1000-clean-20260323-022447/attempt-1/business-summary.json"
+    },
+    {
+      "run_id": "executor-strict-2000-20260323-022125",
+      "attempt": "1",
+      "connection_path": "docs/loadtest-runs/executor-strict-2000-20260323-022125/attempt-1/connection-summary.json",
+      "business_path": "docs/loadtest-runs/executor-strict-2000-20260323-022125/attempt-1/business-summary.json"
+    },
+    {
+      "run_id": "executor-strict-2000-clean-retry-20260323-023138",
+      "attempt": "1",
+      "connection_path": "docs/loadtest-runs/executor-strict-2000-clean-retry-20260323-023138/attempt-1/connection-summary.json",
+      "business_path": "docs/loadtest-runs/executor-strict-2000-clean-retry-20260323-023138/attempt-1/business-summary.json"
     }
   ]
 }

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -29,12 +29,20 @@ curl -s http://localhost:8080/actuator/prometheus | rg "^iot\\."
   - `iot_ingestion_influx_success_total`
   - `iot_ingestion_influx_failure_total`
   - `iot_ingestion_influx_bypass_total`
+  - `iot_ingestion_influx_write_latency_seconds`
   - `iot_ingestion_redis_success_total`
   - `iot_ingestion_redis_failure_total`
+  - `iot_ingestion_redis_heartbeat_latency_seconds`
   - `iot_ingestion_processing_failure_total`
   - `iot_ingestion_pipeline_overall_success_total`
   - `iot_ingestion_pipeline_core_success_total`
   - `iot_ingestion_inflight`
+  - `iot_ingestion_e2e_latency_seconds`
+  - `iot_ingestion_executor_queue_wait_seconds`
+  - `iot_ingestion_executor_rejected_total`
+  - `iot_ingestion_executor_queue_depth`
+  - `iot_ingestion_executor_active`
+  - `iot_ingestion_control_dispatch_latency_seconds`
   - `iot_ingestion_processing_latency_seconds`
 - Downlink:
   - `iot_downlink_command_sent_total`
@@ -49,12 +57,20 @@ curl -s http://localhost:8080/actuator/prometheus | rg "^iot\\."
 - `env`: `${APP_ENV:local}`
 
 ## Ingestion Notes
-- MQTT inbound channel은 executor 기반으로 분리되어 broker 수신 스레드와 downstream 처리 스레드를 느슨하게 분리한다.
+- MQTT inbound channel은 `ingestion.channel.mode=direct|executor`로 전환 가능하다.
+- `executor` 모드에서는 broker 수신 스레드와 downstream 처리 스레드를 느슨하게 분리한다.
 - business success 지표는 아래 두 축으로 본다.
   - overall pipeline success: parse 이후 Influx + Redis가 모두 성공한 건수
   - core pipeline success: parse 이후 Redis heartbeat까지 성공한 건수
 - `strict` 모드는 Influx write path를 포함한 전체 경로 검증용이다.
 - `bypass` 모드는 Influx 압력을 제외하고 parse + Redis + control path를 검증하기 위한 모드다.
+- 주요 성능 비교 지표는 아래 순서로 본다.
+  - `iot_ingestion_e2e_latency_seconds`: channel 진입부터 downstream 처리 종료까지의 전체 지연
+  - `iot_ingestion_processing_latency_seconds`: consumer 실행 이후 처리 지연
+  - `iot_ingestion_executor_queue_wait_seconds`: executor queue 대기 지연
+  - `iot_ingestion_influx_write_latency_seconds`: Influx 저장 지연
+  - `iot_ingestion_redis_heartbeat_latency_seconds`: Redis heartbeat 갱신 지연
+  - `iot_ingestion_control_dispatch_latency_seconds`: control decision + auto command dispatch 지연
 
 ## Grafana
 - Dashboard JSON:

--- a/src/main/java/com/iot/IoT/ingestion/config/MqttConfig.java
+++ b/src/main/java/com/iot/IoT/ingestion/config/MqttConfig.java
@@ -1,23 +1,31 @@
 package com.iot.IoT.ingestion.config;
 
+import com.iot.IoT.ingestion.metrics.IngestionMetricsCollector;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.annotation.IntegrationComponentScan;
+import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.ExecutorChannel;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.mqtt.core.DefaultMqttPahoClientFactory;
 import org.springframework.integration.mqtt.core.MqttPahoClientFactory;
 import org.springframework.integration.mqtt.inbound.MqttPahoMessageDrivenChannelAdapter;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 
 @Configuration
 @IntegrationComponentScan
 public class MqttConfig {
+
+    public static final String INGESTION_ENQUEUED_AT_NANOS_HEADER = "ingestionEnqueuedAtNanos";
+    private static final String CHANNEL_MODE_DIRECT = "direct";
 
     @Value("${spring.mqtt.broker-url}")
     private String brokerUrl;
@@ -43,21 +51,65 @@ public class MqttConfig {
     @Value("${ingestion.executor.queue-capacity:5000}")
     private int executorQueueCapacity;
 
+    @Value("${ingestion.channel.mode:executor}")
+    private String ingestionChannelMode;
+
     @Bean
-    public MessageChannel mqttInputChannel() {
-        return new ExecutorChannel(mqttIngestionExecutor());
+    public MessageChannel mqttInputChannel(
+            Executor mqttIngestionExecutor,
+            IngestionMetricsCollector ingestionMetricsCollector
+    ) {
+        ChannelInterceptor enqueuedAtInterceptor = new ChannelInterceptor() {
+            @Override
+            public org.springframework.messaging.Message<?> preSend(
+                    org.springframework.messaging.Message<?> message,
+                    MessageChannel channel
+            ) {
+                if (message.getHeaders().containsKey(INGESTION_ENQUEUED_AT_NANOS_HEADER)) {
+                    return message;
+                }
+                return MessageBuilder.fromMessage(message)
+                        .setHeader(INGESTION_ENQUEUED_AT_NANOS_HEADER, System.nanoTime())
+                        .build();
+            }
+        };
+
+        if (CHANNEL_MODE_DIRECT.equalsIgnoreCase(ingestionChannelMode)) {
+            DirectChannel channel = new DirectChannel();
+            channel.addInterceptor(enqueuedAtInterceptor);
+            return channel;
+        }
+
+        ExecutorChannel channel = new ExecutorChannel(mqttIngestionExecutor);
+        channel.addInterceptor(enqueuedAtInterceptor);
+        return channel;
     }
 
     @Bean
-    public Executor mqttIngestionExecutor() {
+    public Executor mqttIngestionExecutor(
+            IngestionMetricsCollector ingestionMetricsCollector,
+            io.micrometer.core.instrument.MeterRegistry meterRegistry
+    ) {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setThreadNamePrefix("mqtt-ingest-");
         executor.setCorePoolSize(executorCorePoolSize);
         executor.setMaxPoolSize(Math.max(executorMaxPoolSize, executorCorePoolSize));
         executor.setQueueCapacity(Math.max(executorQueueCapacity, 1));
+        executor.setTaskDecorator(task -> {
+            long enqueuedAtNanos = System.nanoTime();
+            return () -> {
+                ingestionMetricsCollector.recordExecutorQueueWait(System.nanoTime() - enqueuedAtNanos);
+                task.run();
+            };
+        });
+        executor.setRejectedExecutionHandler((task, pool) -> {
+            ingestionMetricsCollector.recordExecutorRejected();
+            throw new RejectedExecutionException("mqtt ingestion executor saturated");
+        });
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(10);
         executor.initialize();
+        ingestionMetricsCollector.registerExecutorMetrics(executor, meterRegistry);
         return executor;
     }
 

--- a/src/main/java/com/iot/IoT/ingestion/consumer/MqttConsumer.java
+++ b/src/main/java/com/iot/IoT/ingestion/consumer/MqttConsumer.java
@@ -45,6 +45,8 @@ public class MqttConsumer {
     @ServiceActivator(inputChannel = "mqttInputChannel")
     public void handle(Message<?> message) {
         long startedAtNanos = System.nanoTime();
+        long enqueuedAtNanos = headerAsLong(message, com.iot.IoT.ingestion.config.MqttConfig.INGESTION_ENQUEUED_AT_NANOS_HEADER)
+                .orElse(startedAtNanos);
         String topic = (String) message.getHeaders().get(MqttHeaders.RECEIVED_TOPIC);
         String rawPayload = payloadAsString(message.getPayload());
         ingestionMetricsCollector.recordMqttReceived();
@@ -87,6 +89,7 @@ public class MqttConsumer {
         } finally {
             ingestionMetricsCollector.decrementInFlight();
             ingestionMetricsCollector.recordProcessingLatency(System.nanoTime() - startedAtNanos);
+            ingestionMetricsCollector.recordEndToEndLatency(System.nanoTime() - enqueuedAtNanos);
         }
     }
 
@@ -105,5 +108,13 @@ public class MqttConsumer {
             return new String(bytes, StandardCharsets.UTF_8);
         }
         return String.valueOf(payload);
+    }
+
+    private java.util.OptionalLong headerAsLong(Message<?> message, String headerName) {
+        Object headerValue = message.getHeaders().get(headerName);
+        if (headerValue instanceof Number number) {
+            return java.util.OptionalLong.of(number.longValue());
+        }
+        return java.util.OptionalLong.empty();
     }
 }

--- a/src/main/java/com/iot/IoT/ingestion/metrics/IngestionMetricsCollector.java
+++ b/src/main/java/com/iot/IoT/ingestion/metrics/IngestionMetricsCollector.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
@@ -36,6 +37,7 @@ public class IngestionMetricsCollector {
     private final LongAdder parseDeadLetterTotal = new LongAdder();
     private final LongAdder storageReplayCandidateTotal = new LongAdder();
     private final LongAdder controlReplayCandidateTotal = new LongAdder();
+    private final LongAdder executorRejectedTotal = new LongAdder();
     private final AtomicInteger inFlight = new AtomicInteger(0);
 
     private final AtomicLong lastMqttReceived = new AtomicLong(0);
@@ -53,6 +55,7 @@ public class IngestionMetricsCollector {
     private final AtomicLong lastParseDeadLetter = new AtomicLong(0);
     private final AtomicLong lastStorageReplayCandidate = new AtomicLong(0);
     private final AtomicLong lastControlReplayCandidate = new AtomicLong(0);
+    private final AtomicLong lastExecutorRejected = new AtomicLong(0);
 
     private final Counter mqttReceivedCounter;
     private final Counter parseSuccessCounter;
@@ -69,7 +72,13 @@ public class IngestionMetricsCollector {
     private final Counter parseDeadLetterCounter;
     private final Counter storageReplayCandidateCounter;
     private final Counter controlReplayCandidateCounter;
+    private final Counter executorRejectedCounter;
     private final Timer processingLatencyTimer;
+    private final Timer endToEndLatencyTimer;
+    private final Timer executorQueueWaitTimer;
+    private final Timer influxWriteLatencyTimer;
+    private final Timer redisHeartbeatLatencyTimer;
+    private final Timer controlDispatchLatencyTimer;
 
     public IngestionMetricsCollector(MeterRegistry meterRegistry) {
         this.mqttReceivedCounter = meterRegistry.counter("iot.ingestion.mqtt.received.total");
@@ -87,7 +96,13 @@ public class IngestionMetricsCollector {
         this.parseDeadLetterCounter = meterRegistry.counter("iot.ingestion.parse.dead_letter.total");
         this.storageReplayCandidateCounter = meterRegistry.counter("iot.ingestion.storage.replay_candidate.total");
         this.controlReplayCandidateCounter = meterRegistry.counter("iot.ingestion.control.replay_candidate.total");
+        this.executorRejectedCounter = meterRegistry.counter("iot.ingestion.executor.rejected.total");
         this.processingLatencyTimer = meterRegistry.timer("iot.ingestion.processing.latency");
+        this.endToEndLatencyTimer = meterRegistry.timer("iot.ingestion.e2e.latency");
+        this.executorQueueWaitTimer = meterRegistry.timer("iot.ingestion.executor.queue.wait");
+        this.influxWriteLatencyTimer = meterRegistry.timer("iot.ingestion.influx.write.latency");
+        this.redisHeartbeatLatencyTimer = meterRegistry.timer("iot.ingestion.redis.heartbeat.latency");
+        this.controlDispatchLatencyTimer = meterRegistry.timer("iot.ingestion.control.dispatch.latency");
         Gauge.builder("iot.ingestion.inflight", inFlight, AtomicInteger::get)
                 .description("Current number of in-flight ingestion tasks")
                 .register(meterRegistry);
@@ -168,6 +183,11 @@ public class IngestionMetricsCollector {
         controlReplayCandidateCounter.increment();
     }
 
+    public void recordExecutorRejected() {
+        executorRejectedTotal.increment();
+        executorRejectedCounter.increment();
+    }
+
     public void incrementInFlight() {
         inFlight.incrementAndGet();
     }
@@ -180,6 +200,51 @@ public class IngestionMetricsCollector {
         if (nanos > 0) {
             processingLatencyTimer.record(Duration.ofNanos(nanos));
         }
+    }
+
+    public void recordEndToEndLatency(long nanos) {
+        if (nanos > 0) {
+            endToEndLatencyTimer.record(Duration.ofNanos(nanos));
+        }
+    }
+
+    public void recordExecutorQueueWait(long nanos) {
+        if (nanos > 0) {
+            executorQueueWaitTimer.record(Duration.ofNanos(nanos));
+        }
+    }
+
+    public void recordInfluxWriteLatency(long nanos) {
+        if (nanos > 0) {
+            influxWriteLatencyTimer.record(Duration.ofNanos(nanos));
+        }
+    }
+
+    public void recordRedisHeartbeatLatency(long nanos) {
+        if (nanos > 0) {
+            redisHeartbeatLatencyTimer.record(Duration.ofNanos(nanos));
+        }
+    }
+
+    public void recordControlDispatchLatency(long nanos) {
+        if (nanos > 0) {
+            controlDispatchLatencyTimer.record(Duration.ofNanos(nanos));
+        }
+    }
+
+    public void registerExecutorMetrics(ThreadPoolTaskExecutor executor, MeterRegistry meterRegistry) {
+        Gauge.builder("iot.ingestion.executor.queue.depth", executor,
+                        candidate -> candidate.getThreadPoolExecutor() == null
+                                ? 0
+                                : candidate.getThreadPoolExecutor().getQueue().size())
+                .description("Current number of queued ingestion tasks")
+                .register(meterRegistry);
+        Gauge.builder("iot.ingestion.executor.active", executor,
+                        candidate -> candidate.getThreadPoolExecutor() == null
+                                ? 0
+                                : candidate.getActiveCount())
+                .description("Current number of active ingestion worker threads")
+                .register(meterRegistry);
     }
 
     @Scheduled(fixedDelayString = "${ingestion.metrics-log-interval-ms:1000}")
@@ -199,6 +264,7 @@ public class IngestionMetricsCollector {
         long parseDeadLetter = parseDeadLetterTotal.sum();
         long storageReplayCandidate = storageReplayCandidateTotal.sum();
         long controlReplayCandidate = controlReplayCandidateTotal.sum();
+        long executorRejected = executorRejectedTotal.sum();
 
         long mqttReceivedDelta = mqttReceived - lastMqttReceived.getAndSet(mqttReceived);
         long parseSuccessDelta = parseSuccess - lastParseSuccess.getAndSet(parseSuccess);
@@ -219,6 +285,7 @@ public class IngestionMetricsCollector {
                 storageReplayCandidate - lastStorageReplayCandidate.getAndSet(storageReplayCandidate);
         long controlReplayCandidateDelta =
                 controlReplayCandidate - lastControlReplayCandidate.getAndSet(controlReplayCandidate);
+        long executorRejectedDelta = executorRejected - lastExecutorRejected.getAndSet(executorRejected);
 
         if (mqttReceivedDelta == 0
                 && parseSuccessDelta == 0
@@ -234,11 +301,12 @@ public class IngestionMetricsCollector {
                 && duplicateDroppedDelta == 0
                 && parseDeadLetterDelta == 0
                 && storageReplayCandidateDelta == 0
-                && controlReplayCandidateDelta == 0) {
+                && controlReplayCandidateDelta == 0
+                && executorRejectedDelta == 0) {
             return;
         }
 
-        log.info("[INGEST-METRICS/1s] recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, influxBypass={}, redisOk={}, redisFail={}, procFail={}, overallOk={}, coreOk={}, dupDrop={}, parseDlq={}, storageReplay={}, controlReplay={}, inFlight={} | totals recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, influxBypass={}, redisOk={}, redisFail={}, procFail={}, overallOk={}, coreOk={}, dupDrop={}, parseDlq={}, storageReplay={}, controlReplay={}",
+        log.info("[INGEST-METRICS/1s] recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, influxBypass={}, redisOk={}, redisFail={}, procFail={}, overallOk={}, coreOk={}, dupDrop={}, parseDlq={}, storageReplay={}, controlReplay={}, executorRejected={}, inFlight={} | totals recv={}, parseOk={}, parseFail={}, influxOk={}, influxFail={}, influxBypass={}, redisOk={}, redisFail={}, procFail={}, overallOk={}, coreOk={}, dupDrop={}, parseDlq={}, storageReplay={}, controlReplay={}, executorRejected={}",
                 mqttReceivedDelta,
                 parseSuccessDelta,
                 parseFailureDelta,
@@ -254,6 +322,7 @@ public class IngestionMetricsCollector {
                 parseDeadLetterDelta,
                 storageReplayCandidateDelta,
                 controlReplayCandidateDelta,
+                executorRejectedDelta,
                 inFlight.get(),
                 mqttReceived,
                 parseSuccess,
@@ -269,6 +338,7 @@ public class IngestionMetricsCollector {
                 duplicateDropped,
                 parseDeadLetter,
                 storageReplayCandidate,
-                controlReplayCandidate);
+                controlReplayCandidate,
+                executorRejected);
     }
 }

--- a/src/main/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImpl.java
+++ b/src/main/java/com/iot/IoT/ingestion/service/DeviceIngestionServiceImpl.java
@@ -52,6 +52,7 @@ public class DeviceIngestionServiceImpl implements DeviceIngestionService {
         if (isInfluxWriteBypassMode()) {
             ingestionMetricsCollector.recordInfluxBypass();
         } else {
+            long influxStartedAtNanos = System.nanoTime();
             try {
                 temperatureTimeSeriesPort.save(message, now);
                 influxWritten = true;
@@ -67,9 +68,12 @@ public class DeviceIngestionServiceImpl implements DeviceIngestionService {
                         e);
                 log.error("[RELIABILITY] Storage failure classified. store=INFLUX, deviceId={}, replayable=true",
                         message.deviceId(), e);
+            } finally {
+                ingestionMetricsCollector.recordInfluxWriteLatency(System.nanoTime() - influxStartedAtNanos);
             }
         }
 
+        long redisStartedAtNanos = System.nanoTime();
         try {
             heartbeatPort.updateLastSeen(message.deviceId(), now);
             redisUpdated = true;
@@ -80,6 +84,8 @@ public class DeviceIngestionServiceImpl implements DeviceIngestionService {
             log.error("[INGESTION] Redis heartbeat update failed. deviceId={}", message.deviceId(), e);
             log.error("[RELIABILITY] Storage failure classified. store=REDIS, deviceId={}, replayable=true",
                     message.deviceId(), e);
+        } finally {
+            ingestionMetricsCollector.recordRedisHeartbeatLatency(System.nanoTime() - redisStartedAtNanos);
         }
 
         if (redisUpdated) {
@@ -89,6 +95,7 @@ public class DeviceIngestionServiceImpl implements DeviceIngestionService {
             ingestionMetricsCollector.recordOverallPipelineSuccess();
         }
 
+        long controlDispatchStartedAtNanos = System.nanoTime();
         try {
             ControlAction action = controlDecisionEngine.decide(message);
             log.info("[CONTROL] Decision made. deviceId={}, temp={}, targetTemp={}, state={}, action={}",
@@ -103,6 +110,8 @@ public class DeviceIngestionServiceImpl implements DeviceIngestionService {
             log.error("[CONTROL] Auto control dispatch failed. deviceId={}", message.deviceId(), ex);
             log.error("[RELIABILITY] Control dispatch failure classified. deviceId={}, replayable=true",
                     message.deviceId(), ex);
+        } finally {
+            ingestionMetricsCollector.recordControlDispatchLatency(System.nanoTime() - controlDispatchStartedAtNanos);
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,8 +13,8 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        format_sql: true
-        show_sql: true
+        format_sql: false
+        show_sql: false
 
   # 2. Redis Configuration
   data:
@@ -38,7 +38,13 @@ influxdb:
   bucket: sousvide_bucket
 
 ingestion:
+  channel:
+    mode: executor
   heartbeat-ttl-seconds: 120
+  executor:
+    core-pool-size: 4
+    max-pool-size: 16
+    queue-capacity: 5000
   influx:
     write-mode: strict
   metrics:
@@ -47,13 +53,16 @@ ingestion:
 control:
   deadband: 0.3
 watchdog:
-  scan-interval-ms: 5000
+  scan-interval-ms: 30000
   offline-notify-cooldown-seconds: 60
 
 logging:
   level:
     root: INFO
-    org.springframework.integration: DEBUG
+    org.springframework.integration: INFO
+    org.hibernate.SQL: WARN
+    org.hibernate.orm.jdbc.bind: WARN
+    com.iot.IoT.watchdog: WARN
 
 management:
   endpoints:


### PR DESCRIPTION
 ## 무엇을 변경했는가
  - ingestion 경로에 단계별 성능 계측을 추가했다.
  - MQTT 입력 채널을 `direct` / `executor` 모드로 전환 가능하게 만들었다.
  - end-to-end latency, executor queue wait, Influx write latency, Redis heartbeat latency, control dispatch latency 메트릭을 추가했다.
  - observability 문서와 load test 결과 문서를 업데이트했다.
  - `direct + bypass`, `executor + bypass`, `executor + strict` 실험 결과를 정리했다.

  ## 왜 변경했는가
  - 기존에는 ingestion 처리 성공/실패 중심으로만 확인 가능했고, 병목이 어느 구간에서 발생하는지 분리해서 보기 어려웠다.
  - `ExecutorChannel` 적용 효과를 정량적으로 확인하려면 queue wait, processing, e2e latency를 함께 측정할 필요가 있었다.
  - Influx write를 제외한 core path 비교와, Influx를 포함한 strict 경로 검증을 분리해서 확인하기 위해 계측과 실험 정리가 필요했다.

  ## 어떻게 검증했는가
  - actuator/prometheus에서 신규 메트릭 노출을 확인했다.
  - `direct + bypass` 조건에서 1000 / 2000 / 3000 device 부하 테스트를 실행했다.
  - `executor + bypass` 조건에서 동일 부하 테스트를 실행했다.
  - Influx authorization 복구 후 `executor + strict` 조건에서 1000 / 2000 / 3000 device 부하 테스트를 실행했다.
  - 결과 산출물:
    - `docs/loadtest-runs/.../connection-summary.json`
    - `docs/loadtest-runs/.../business-summary.json`

  ## 주요 결과
  - `direct + bypass` 대비 `executor + bypass`에서 core pipeline success rate가 개선됐다.
    - 1000 connections: `89.34% -> 97.61%` (`+8.27%p`)
    - 2000 connections: `89.50% -> 98.77%` (`+9.27%p`)
    - 3000 connections: `92.53% -> 99.59%` (`+7.06%p`)
  - Influx를 포함한 strict 경로에서도 executor 기반 처리로 높은 성공률을 확인했다.
    - 1000 connections: overall success `98.10%`
    - 2000 connections: overall success `99.92%`
    - 3000 connections: overall success `99.57%`

  ## 리스크 / 한계
  - bypass 모드에서는 Influx actual write를 제외하므로 `overall pipeline success` 대신 `core pipeline success`를 기준으로 해석해야 한다.
  - strict 결과 중 일부 business summary는 `backend.log`를 attempt 디렉터리로 복사한 뒤 수동 생성했다.
  - executor 실험 세션에서 `executor_rejected_total`이 관측되어 saturation 지표는 후속 추적이 필요하다.